### PR TITLE
fix: search notes by title and body with case-insensitive match (#3)

### DIFF
--- a/apps/pages/src/features/link-picker/link-picker.tsx
+++ b/apps/pages/src/features/link-picker/link-picker.tsx
@@ -17,15 +17,15 @@ export const LinkPicker = ({ sourceNodeId, onClose }: LinkPickerProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
 
-  const { data: notes = [] } = useQuery({
-    queryKey: queryKeys.notes,
-    queryFn: () => graph.getNotes(),
+  const trimmed = search.trim();
+
+  const { data: results = [] } = useQuery({
+    queryKey: queryKeys.search(trimmed),
+    queryFn: () => graph.searchNotes(trimmed),
+    enabled: trimmed.length > 0,
   });
 
-  const filtered = notes.filter(
-    (note: Note) =>
-      note.id !== sourceNodeId && note.title.toLowerCase().includes(search.toLowerCase()),
-  );
+  const filtered = results.filter((note: Note) => note.id !== sourceNodeId);
 
   const createLinkMutation = useMutation({
     mutationFn: async ({ targetId }: { targetId: string }) =>
@@ -76,7 +76,7 @@ export const LinkPicker = ({ sourceNodeId, onClose }: LinkPickerProps) => {
           className="w-full px-4 py-3 bg-transparent border-b border-border outline-none text-sm"
           autoFocus
         />
-        {search && filtered.length > 0 && (
+        {trimmed && filtered.length > 0 && (
           <div className="max-h-[200px] overflow-y-auto py-1">
             {filtered.map((note: Note, index: number) => (
               <button
@@ -91,7 +91,7 @@ export const LinkPicker = ({ sourceNodeId, onClose }: LinkPickerProps) => {
             ))}
           </div>
         )}
-        {search && filtered.length === 0 && (
+        {trimmed && filtered.length === 0 && (
           <div className="px-4 py-3 text-sm text-muted-foreground">該当するノートがありません</div>
         )}
       </div>

--- a/apps/pages/src/lib/query.ts
+++ b/apps/pages/src/lib/query.ts
@@ -13,4 +13,5 @@ export const queryKeys = {
   graph: ["graph"] as const,
   notes: ["notes"] as const,
   note: (id: string) => ["note", id] as const,
+  search: (query: string) => ["search", query] as const,
 };

--- a/apps/server/src/routes/notes.ts
+++ b/apps/server/src/routes/notes.ts
@@ -8,6 +8,12 @@ notesRouter.get("/", async (c) => {
   return c.json(notes);
 });
 
+notesRouter.get("/search", async (c) => {
+  const q = c.req.query("q") ?? "";
+  const notes = await graph.searchNotes(q);
+  return c.json(notes);
+});
+
 notesRouter.get("/:id", async (c) => {
   const note = await graph.getNote(c.req.param("id"));
   return note ? c.json(note) : c.json({ error: "Not found" }, 404);

--- a/apps/web/src/features/link-picker/link-picker.tsx
+++ b/apps/web/src/features/link-picker/link-picker.tsx
@@ -15,15 +15,15 @@ export const LinkPicker = ({ sourceNodeId, onClose }: LinkPickerProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
 
-  const { data: notes = [] } = useQuery({
-    queryKey: queryKeys.notes,
-    queryFn: api.getNotes,
+  const trimmed = search.trim();
+
+  const { data: results = [] } = useQuery({
+    queryKey: queryKeys.search(trimmed),
+    queryFn: () => api.searchNotes(trimmed),
+    enabled: trimmed.length > 0,
   });
 
-  const filtered = notes.filter(
-    (note: Note) =>
-      note.id !== sourceNodeId && note.title.toLowerCase().includes(search.toLowerCase()),
-  );
+  const filtered = results.filter((note: Note) => note.id !== sourceNodeId);
 
   const createLinkMutation = useMutation({
     mutationFn: ({ targetId }: { targetId: string }) => api.createLink(sourceNodeId, targetId),
@@ -73,7 +73,7 @@ export const LinkPicker = ({ sourceNodeId, onClose }: LinkPickerProps) => {
           className="w-full px-4 py-3 bg-transparent border-b border-border outline-none text-sm"
           autoFocus
         />
-        {search && filtered.length > 0 && (
+        {trimmed && filtered.length > 0 && (
           <div className="max-h-[200px] overflow-y-auto py-1">
             {filtered.map((note: Note, index: number) => (
               <button
@@ -88,7 +88,7 @@ export const LinkPicker = ({ sourceNodeId, onClose }: LinkPickerProps) => {
             ))}
           </div>
         )}
-        {search && filtered.length === 0 && (
+        {trimmed && filtered.length === 0 && (
           <div className="px-4 py-3 text-sm text-muted-foreground">該当するノートがありません</div>
         )}
       </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -19,6 +19,7 @@ const fetchJson = async <T>(url: string, init?: RequestInit): Promise<T> => {
 
 export const api = {
   getNotes: () => fetchJson<Note[]>("/notes"),
+  searchNotes: (query: string) => fetchJson<Note[]>(`/notes/search?q=${encodeURIComponent(query)}`),
   getNote: (id: string) => fetchJson<NoteWithContent>(`/notes/${id}`),
   createNote: (title: string) =>
     fetchJson<Note>("/notes", { method: "POST", body: JSON.stringify({ title }) }),

--- a/apps/web/src/lib/query.ts
+++ b/apps/web/src/lib/query.ts
@@ -13,4 +13,5 @@ export const queryKeys = {
   graph: ["graph"] as const,
   notes: ["notes"] as const,
   note: (id: string) => ["note", id] as const,
+  search: (query: string) => ["search", query] as const,
 };

--- a/packages/core/src/knowledge-graph.ts
+++ b/packages/core/src/knowledge-graph.ts
@@ -20,6 +20,7 @@ export type KnowledgeGraphConfig = {
 export type KnowledgeGraph = {
   getNotes: () => Promise<Note[]>;
   getNote: (id: string) => Promise<NoteWithContent | undefined>;
+  searchNotes: (query: string) => Promise<Note[]>;
   createNote: (title: string) => Promise<Result<Note, CreateNoteError>>;
   renameNote: (id: string, title: string) => Promise<Result<Note, RenameNoteError>>;
   deleteNote: (id: string) => Promise<Result<{ ok: true }, "NOT_FOUND">>;
@@ -42,6 +43,20 @@ export const createKnowledgeGraph = (config: KnowledgeGraphConfig): KnowledgeGra
       if (!note) return undefined;
       const content = await adapter.getContent(id);
       return { ...note, content };
+    },
+
+    searchNotes: async (query) => {
+      const trimmed = query.trim();
+      if (!trimmed) return [];
+
+      const needle = trimmed.toLowerCase();
+      const notes = await adapter.getAllNotes();
+      const contents = await Promise.all(notes.map((n) => adapter.getContent(n.id)));
+
+      return notes.filter((note, i) => {
+        const haystack = `${note.title}\n${contents[i] ?? ""}`.toLowerCase();
+        return haystack.includes(needle);
+      });
     },
 
     createNote: async (title) => {

--- a/packages/core/tests/knowledge-graph.test.ts
+++ b/packages/core/tests/knowledge-graph.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect, beforeEach } from "vite-plus/test";
+import { createKnowledgeGraph } from "../src/knowledge-graph.ts";
+import type { StorageAdapter, Note, Link } from "../src/index.ts";
+
+const createMemoryAdapter = (): StorageAdapter => {
+  const notes = new Map<string, Note>();
+  const contents = new Map<string, string>();
+  const links = new Map<string, Link>();
+
+  return {
+    getAllNotes: async () =>
+      [...notes.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+    getNoteById: async (id) => notes.get(id),
+    getNoteByTitle: async (title) => [...notes.values()].find((n) => n.title === title),
+    insertNote: async (note) => {
+      notes.set(note.id, note);
+    },
+    updateNote: async (id, fields) => {
+      const cur = notes.get(id);
+      if (!cur) return;
+      notes.set(id, {
+        ...cur,
+        ...(fields.title !== undefined ? { title: fields.title } : {}),
+        updatedAt: fields.updatedAt,
+      });
+    },
+    deleteNote: async (id) => {
+      notes.delete(id);
+    },
+    getContent: async (id) => contents.get(id) ?? "",
+    saveContent: async (id, content) => {
+      contents.set(id, content);
+    },
+    deleteContent: async (id) => {
+      contents.delete(id);
+    },
+    getAllLinks: async () => [...links.values()],
+    getLinkById: async (id) => links.get(id),
+    findLink: async (sourceId, targetId) =>
+      [...links.values()].find(
+        (l) =>
+          (l.sourceId === sourceId && l.targetId === targetId) ||
+          (l.sourceId === targetId && l.targetId === sourceId),
+      ),
+    insertLink: async (link) => {
+      links.set(link.id, link);
+    },
+    deleteLink: async (id) => {
+      links.delete(id);
+    },
+  };
+};
+
+describe("searchNotes", () => {
+  let graph: ReturnType<typeof createKnowledgeGraph>;
+  let idCounter = 0;
+
+  beforeEach(async () => {
+    idCounter = 0;
+    graph = createKnowledgeGraph({
+      adapter: createMemoryAdapter(),
+      generateId: () => `id-${++idCounter}`,
+      now: () => new Date(2026, 0, idCounter).toISOString(),
+    });
+  });
+
+  test("empty query returns no results", async () => {
+    await graph.createNote("TODO");
+    expect(await graph.searchNotes("")).toEqual([]);
+    expect(await graph.searchNotes("   ")).toEqual([]);
+  });
+
+  test("matches ASCII title regardless of case", async () => {
+    await graph.createNote("TODO");
+    await graph.createNote("Shopping");
+
+    const byUpper = await graph.searchNotes("TODO");
+    expect(byUpper.map((n) => n.title)).toEqual(["TODO"]);
+
+    const byLower = await graph.searchNotes("todo");
+    expect(byLower.map((n) => n.title)).toEqual(["TODO"]);
+
+    const partial = await graph.searchNotes("shop");
+    expect(partial.map((n) => n.title)).toEqual(["Shopping"]);
+  });
+
+  test("matches Japanese title", async () => {
+    await graph.createNote("買い物メモ");
+    const hits = await graph.searchNotes("買");
+    expect(hits.map((n) => n.title)).toEqual(["買い物メモ"]);
+  });
+
+  test("matches by body content", async () => {
+    const created = await graph.createNote("買い物メモ");
+    if (!created.ok) throw new Error("setup failed");
+    await graph.saveContent(created.value.id, "仕事のタスク\n牛乳");
+
+    const byBodyJa = await graph.searchNotes("仕事");
+    expect(byBodyJa.map((n) => n.title)).toEqual(["買い物メモ"]);
+
+    const byBodyMixedCase = await graph.searchNotes("牛乳");
+    expect(byBodyMixedCase.map((n) => n.title)).toEqual(["買い物メモ"]);
+  });
+
+  test("matches ASCII body case-insensitively", async () => {
+    const created = await graph.createNote("ノートA");
+    if (!created.ok) throw new Error("setup failed");
+    await graph.saveContent(created.value.id, "Remember the Milk");
+
+    expect((await graph.searchNotes("milk")).map((n) => n.title)).toEqual(["ノートA"]);
+    expect((await graph.searchNotes("MILK")).map((n) => n.title)).toEqual(["ノートA"]);
+  });
+
+  test("returns empty when no note matches", async () => {
+    await graph.createNote("TODO");
+    expect(await graph.searchNotes("xyz-not-present")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 概要
- `core` に `searchNotes(query)` を追加し、タイトルと本文を合わせて case-insensitive な部分一致で検索する
- サーバー (`/api/notes/search?q=`) と IDB 版クライアント (`useGraph().searchNotes`) の両方にエンドポイントを追加
- link-picker から `searchNotes` を呼び直し、入力がトリム後に空のときはリクエストを送らないようにした

## 背景
Closes #3

- `TODO` や `todo` のような ASCII タイトルが一切ヒットしなかった
- 本文はそもそもインデックス対象外で、「仕事のタスク」と書いても「仕事」で検索できなかった

## 検証
- [x] `vp check` pass
- [x] `vp test` pass (新規に追加した `packages/core/tests/knowledge-graph.test.ts` 6 件を含む 23 件)
- [ ] Playwright での目視確認は省略（ロジック中心の変更で unit test によりカバー済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)