### PR TITLE
fix: show note title in delete confirmation dialog (#7)

### DIFF
--- a/apps/pages/src/features/graph/graph-view.tsx
+++ b/apps/pages/src/features/graph/graph-view.tsx
@@ -183,6 +183,16 @@ export const GraphView = () => {
     setDeleteNodeId(null);
   };
 
+  // Resolve the title of the node currently targeted for deletion so the
+  // confirmation dialog can name it explicitly. Falls back to "このノート"
+  // when the node is missing a label (untitled drafts, race conditions).
+  const deleteTargetLabel = (() => {
+    if (!deleteNodeId) return null;
+    const node = nodes.find((n) => n.id === deleteNodeId);
+    const label = node?.label?.trim();
+    return label && label.length > 0 ? label : null;
+  })();
+
   const handleDeleteLink = (edgeId: string) => {
     deleteLinkMutation.mutate(edgeId);
     setContextMenu(null);
@@ -415,7 +425,14 @@ export const GraphView = () => {
           <AlertDialogHeader>
             <AlertDialogTitle>ノートを削除</AlertDialogTitle>
             <AlertDialogDescription>
-              このノートを削除しますか？この操作は取り消せません。
+              {deleteTargetLabel ? (
+                <>
+                  「<span className="font-medium text-foreground">{deleteTargetLabel}</span>
+                  」を削除しますか？この操作は取り消せません。
+                </>
+              ) : (
+                <>このノートを削除しますか？この操作は取り消せません。</>
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/apps/web/src/features/graph/graph-view.tsx
+++ b/apps/web/src/features/graph/graph-view.tsx
@@ -136,6 +136,16 @@ export const GraphView = () => {
     setDeleteNodeId(null);
   };
 
+  // Resolve the title of the node currently targeted for deletion so the
+  // confirmation dialog can name it explicitly. Falls back to "このノート"
+  // when the node is missing a label (untitled drafts, race conditions).
+  const deleteTargetLabel = (() => {
+    if (!deleteNodeId) return null;
+    const node = nodes.find((n) => n.id === deleteNodeId);
+    const label = node?.label?.trim();
+    return label && label.length > 0 ? label : null;
+  })();
+
   const handleDeleteLink = (edgeId: string) => {
     deleteLinkMutation.mutate(edgeId);
     setContextMenu(null);
@@ -485,7 +495,14 @@ export const GraphView = () => {
           <AlertDialogHeader>
             <AlertDialogTitle>ノートを削除</AlertDialogTitle>
             <AlertDialogDescription>
-              このノートを削除しますか？この操作は取り消せません。
+              {deleteTargetLabel ? (
+                <>
+                  「<span className="font-medium text-foreground">{deleteTargetLabel}</span>
+                  」を削除しますか？この操作は取り消せません。
+                </>
+              ) : (
+                <>このノートを削除しますか？この操作は取り消せません。</>
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
## 概要
グラフキャンバスでノードを右クリック→削除した際、確認ダイアログに対象のノート名を埋め込むよう変更しました。複数ノードがある状況でどのノートを削除しようとしているかが一目で分かります。

## 背景
Closes #7

「『TODO』を削除しますか？」のように対象名を出してほしい、という要望。これまでは「このノートを削除しますか？」固定で、右クリック位置とメニュー位置のズレもあって不安が残っていた。

## 変更点
- 削除対象の `nodeId` から `nodes` 配列のラベルを引き、ダイアログ本文に対象タイトルを表示
- タイトルは強調表示（`font-medium text-foreground`）して引用符で囲む
- ラベルが空／空白のみのときは従来文言「このノート」にフォールバック
- 同じ削除UIを持つ `apps/web` 側も合わせて更新

## 検証
- [x] `vp check` pass（format / lint / typecheck）
- [x] `vp test` pass（23 tests）
- [ ] Playwright での目視確認は他の usability fix と並行作業中のため省略（純粋な文言変更で副作用なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)