### PR TITLE
refactor: drop note title uniqueness constraint

### DIFF
--- a/apps/server/src/routes/notes.ts
+++ b/apps/server/src/routes/notes.ts
@@ -23,8 +23,7 @@ notesRouter.post("/", async (c) => {
   const { title } = await c.req.json<{ title: string }>();
   const result = await graph.createNote(title);
   if (!result.ok) {
-    const status = result.error === "TITLE_DUPLICATE" ? 409 : 400;
-    return c.json({ error: result.error }, status);
+    return c.json({ error: result.error }, 400);
   }
   return c.json(result.value, 201);
 });
@@ -33,8 +32,7 @@ notesRouter.patch("/:id", async (c) => {
   const { title } = await c.req.json<{ title: string }>();
   const result = await graph.renameNote(c.req.param("id"), title);
   if (!result.ok) {
-    const status =
-      result.error === "TITLE_DUPLICATE" ? 409 : result.error === "NOT_FOUND" ? 404 : 400;
+    const status = result.error === "NOT_FOUND" ? 404 : 400;
     return c.json({ error: result.error }, status);
   }
   return c.json(result.value);

--- a/packages/adapter-idb/src/index.ts
+++ b/packages/adapter-idb/src/index.ts
@@ -26,7 +26,6 @@ const openDb = (name: string): Promise<IDBDatabase> =>
       const db = request.result;
 
       const notes = db.createObjectStore("notes", { keyPath: "id" });
-      notes.createIndex("title", "title", { unique: true });
       notes.createIndex("updatedAt", "updatedAt", { unique: false });
 
       db.createObjectStore("content", { keyPath: "id" });
@@ -56,11 +55,6 @@ export const createIdbAdapter = async (config?: IdbAdapterConfig): Promise<Stora
 
     getNoteById: async (id) => {
       const row = await req(store("notes", "readonly").get(id));
-      return row as Note | undefined;
-    },
-
-    getNoteByTitle: async (title) => {
-      const row = await req(store("notes", "readonly").index("title").get(title));
       return row as Note | undefined;
     },
 

--- a/packages/adapter-idb/tests/index.test.ts
+++ b/packages/adapter-idb/tests/index.test.ts
@@ -49,12 +49,6 @@ describe("notes", () => {
     expect(await adapter.getNoteById("999")).toBeUndefined();
   });
 
-  test("getNoteByTitle", async () => {
-    await adapter.insertNote(note("1", "Hello"));
-    expect(await adapter.getNoteByTitle("Hello")).toEqual(note("1", "Hello"));
-    expect(await adapter.getNoteByTitle("Missing")).toBeUndefined();
-  });
-
   test("updateNote title", async () => {
     await adapter.insertNote(note("1", "Hello"));
     await adapter.updateNote("1", { title: "Updated", updatedAt: "2024-02-01T00:00:00Z" });

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -47,7 +47,7 @@ export const createSqliteAdapter = (config: SqliteAdapterConfig): StorageAdapter
   db.exec(`
     CREATE TABLE IF NOT EXISTS notes (
       id         TEXT PRIMARY KEY,
-      title      TEXT UNIQUE NOT NULL,
+      title      TEXT NOT NULL,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     )
@@ -72,13 +72,6 @@ export const createSqliteAdapter = (config: SqliteAdapterConfig): StorageAdapter
 
     getNoteById: async (id) => {
       const row = db.prepare("SELECT * FROM notes WHERE id = ?").get(id) as NoteRow | undefined;
-      return row ? toNote(row) : undefined;
-    },
-
-    getNoteByTitle: async (title) => {
-      const row = db.prepare("SELECT * FROM notes WHERE title = ?").get(title) as
-        | NoteRow
-        | undefined;
       return row ? toNote(row) : undefined;
     },
 

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -4,7 +4,6 @@ export type StorageAdapter = {
   // Notes
   getAllNotes: () => Promise<Note[]>;
   getNoteById: (id: string) => Promise<Note | undefined>;
-  getNoteByTitle: (title: string) => Promise<Note | undefined>;
   insertNote: (note: Note) => Promise<void>;
   updateNote: (id: string, fields: { title?: string; updatedAt: string }) => Promise<void>;
   deleteNote: (id: string) => Promise<void>;

--- a/packages/core/src/knowledge-graph.ts
+++ b/packages/core/src/knowledge-graph.ts
@@ -63,9 +63,6 @@ export const createKnowledgeGraph = (config: KnowledgeGraphConfig): KnowledgeGra
       const titleError = validateTitle(title);
       if (titleError) return { ok: false, error: titleError };
 
-      const existing = await adapter.getNoteByTitle(title);
-      if (existing) return { ok: false, error: "TITLE_DUPLICATE" };
-
       const id = generateId();
       const timestamp = now();
       const note: Note = { id, title, createdAt: timestamp, updatedAt: timestamp };
@@ -82,9 +79,6 @@ export const createKnowledgeGraph = (config: KnowledgeGraphConfig): KnowledgeGra
 
       const note = await adapter.getNoteById(id);
       if (!note) return { ok: false, error: "NOT_FOUND" };
-
-      const conflict = await adapter.getNoteByTitle(title);
-      if (conflict && conflict.id !== id) return { ok: false, error: "TITLE_DUPLICATE" };
 
       const timestamp = now();
       await adapter.updateNote(id, { title, updatedAt: timestamp });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,8 +33,8 @@ export type GraphData = {
 
 export type Result<T, E extends string> = { ok: true; value: T } | { ok: false; error: E };
 
-export type CreateNoteError = "TITLE_REQUIRED" | "TITLE_INVALID" | "TITLE_DUPLICATE";
-export type RenameNoteError = "NOT_FOUND" | "TITLE_REQUIRED" | "TITLE_INVALID" | "TITLE_DUPLICATE";
+export type CreateNoteError = "TITLE_REQUIRED" | "TITLE_INVALID";
+export type RenameNoteError = "NOT_FOUND" | "TITLE_REQUIRED" | "TITLE_INVALID";
 export type CreateLinkError =
   | "SELF_LINK"
   | "SOURCE_NOT_FOUND"

--- a/packages/core/tests/knowledge-graph.test.ts
+++ b/packages/core/tests/knowledge-graph.test.ts
@@ -11,7 +11,6 @@ const createMemoryAdapter = (): StorageAdapter => {
     getAllNotes: async () =>
       [...notes.values()].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
     getNoteById: async (id) => notes.get(id),
-    getNoteByTitle: async (title) => [...notes.values()].find((n) => n.title === title),
     insertNote: async (note) => {
       notes.set(note.id, note);
     },


### PR DESCRIPTION
## Summary
- ノートタイトルの一意性制約を全層から除去 (`packages/core` の `TITLE_DUPLICATE` チェック、IDB の unique index、SQLite の `UNIQUE` 制約、`apps/server` の 409 マッピング)
- 重複チェック以外で利用されていなかった `getNoteByTitle` を `StorageAdapter` interface と各 adapter 実装から削除
- マイグレーションは無視 — 既存の SQLite ファイルには UNIQUE 制約が残るため、必要に応じて DB ファイルを再作成すること

## Test plan
- [x] `vp run -r check` — 全パッケージで lint / fmt / type check パス
- [x] `packages/core` `vp test` — 6 件パス
- [x] `packages/adapter-idb` `vp test` — 16 件パス
- [ ] 手動: `apps/pages` で同名ノートを2件作成できることを確認
- [ ] 手動: `apps/server` 経由で同名ノートを `POST /notes` できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)