### PR TITLE
docs: fix check command in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@
 
 ```bash
 # run lint, fmt and type check for all packages
-vp run check
+vp run checkAll
 ```
 
 それ以外のパッケージ個別のコマンドはパッケージごとの`README.md`を参照


### PR DESCRIPTION
## Summary
- `CLAUDE.md` の手順にある `vp run check` はタスク未定義でエラーになるため、全パッケージ向けの `vp run checkAll` に修正

## Test plan
- [x] `vp run checkAll` がワークスペース全体で lint / fmt / type check を実行することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)