### PR TITLE
feat: ノート間リンクに向き(無向/A→B/B→A)を追加

### DIFF
--- a/apps/pages/src/features/graph/graph-view.tsx
+++ b/apps/pages/src/features/graph/graph-view.tsx
@@ -24,6 +24,7 @@ const CANVAS_HINT_STORAGE_KEY = "graph-canvas-hint-dismissed";
 const ZOOM_MIN = 0.1;
 const ZOOM_MAX = 5;
 const ZOOM_STEP = 1.2;
+const NODE_RADIUS = 20;
 
 type ContextMenu = {
   x: number;
@@ -339,11 +340,24 @@ export const GraphView = () => {
       typeof link.source === "object" ? link.source : nodes.find((n) => n.id === link.source);
     const target =
       typeof link.target === "object" ? link.target : nodes.find((n) => n.id === link.target);
+    const sx = source?.x ?? 0;
+    const sy = source?.y ?? 0;
+    const tx = target?.x ?? 0;
+    const ty = target?.y ?? 0;
+    if (link.direction !== "directed") {
+      return { x1: sx, y1: sy, x2: tx, y2: ty };
+    }
+    // Pull the endpoint back by the node radius so the arrowhead lands on the
+    // circle's edge instead of being swallowed by it.
+    const dx = tx - sx;
+    const dy = ty - sy;
+    const len = Math.hypot(dx, dy) || 1;
+    const offset = NODE_RADIUS + 4;
     return {
-      x1: source?.x ?? 0,
-      y1: source?.y ?? 0,
-      x2: target?.x ?? 0,
-      y2: target?.y ?? 0,
+      x1: sx,
+      y1: sy,
+      x2: tx - (dx / len) * offset,
+      y2: ty - (dy / len) * offset,
     };
   };
 
@@ -358,6 +372,20 @@ export const GraphView = () => {
           onMouseUp={handleMouseUp}
           onMouseLeave={handleMouseUp}
         >
+          <defs>
+            <marker
+              id="graph-arrow"
+              viewBox="0 0 10 10"
+              refX="10"
+              refY="5"
+              markerWidth="6"
+              markerHeight="6"
+              markerUnits="userSpaceOnUse"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="#94a3b8" />
+            </marker>
+          </defs>
           <g transform={`translate(${transform.x},${transform.y}) scale(${transform.scale})`}>
             {links.map((link) => {
               const coords = getLinkCoords(link);
@@ -370,6 +398,8 @@ export const GraphView = () => {
                   y2={coords.y2}
                   stroke="#94a3b8"
                   strokeWidth={2}
+                  markerEnd={link.direction === "directed" ? "url(#graph-arrow)" : undefined}
+                  data-direction={link.direction}
                   className="cursor-pointer"
                   onContextMenu={(e) =>
                     handleContextMenu(e, {
@@ -411,7 +441,7 @@ export const GraphView = () => {
                   }
                 }}
               >
-                <circle r={20} fill="#3b82f6" stroke="#1d4ed8" strokeWidth={2} />
+                <circle r={NODE_RADIUS} fill="#3b82f6" stroke="#1d4ed8" strokeWidth={2} />
                 <text
                   dy={-28}
                   textAnchor="middle"
@@ -462,7 +492,11 @@ export const GraphView = () => {
 
         {/* Link Picker */}
         {linkPickerNodeId && (
-          <LinkPicker sourceNodeId={linkPickerNodeId} onClose={() => setLinkPickerNodeId(null)} />
+          <LinkPicker
+            sourceNodeId={linkPickerNodeId}
+            sourceLabel={nodes.find((n) => n.id === linkPickerNodeId)?.label ?? ""}
+            onClose={() => setLinkPickerNodeId(null)}
+          />
         )}
 
         {/* Search Palette (Cmd+K / Ctrl+K) */}

--- a/apps/pages/src/features/graph/graph-view.tsx
+++ b/apps/pages/src/features/graph/graph-view.tsx
@@ -6,6 +6,7 @@ import { useGraph } from "../../lib/graph";
 import { unwrap } from "../../lib/unwrap";
 import { queryKeys } from "../../lib/query";
 import { useDocumentTitle } from "../../lib/use-document-title";
+import type { EditLinkDirection } from "core";
 import { useGraphSimulation, type SimNode, type SimLink } from "./use-graph-simulation";
 import { LinkPicker } from "../../features/link-picker/link-picker";
 import { SearchPalette } from "../../features/search-palette/search-palette";
@@ -187,6 +188,14 @@ export const GraphView = () => {
     },
   });
 
+  const updateLinkDirectionMutation = useMutation({
+    mutationFn: async ({ id, change }: { id: string; change: EditLinkDirection }) =>
+      unwrap(await graph.updateLinkDirection(id, change)),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.graph });
+    },
+  });
+
   const handleNodeClick = (nodeId: string) => {
     if (!dragNode) {
       void navigate(`/notes/${nodeId}`);
@@ -222,6 +231,11 @@ export const GraphView = () => {
 
   const handleDeleteLink = (edgeId: string) => {
     deleteLinkMutation.mutate(edgeId);
+    setContextMenu(null);
+  };
+
+  const handleEditLinkDirection = (edgeId: string, change: EditLinkDirection) => {
+    updateLinkDirectionMutation.mutate({ id: edgeId, change });
     setContextMenu(null);
   };
 
@@ -479,14 +493,72 @@ export const GraphView = () => {
                 </button>
               </>
             )}
-            {contextMenu.type === "edge" && (
-              <button
-                className="w-full text-left px-3 py-1.5 text-sm hover:bg-accent text-destructive"
-                onClick={() => handleDeleteLink(contextMenu.edgeId)}
-              >
-                削除
-              </button>
-            )}
+            {contextMenu.type === "edge" &&
+              (() => {
+                const edge = links.find((l) => l.id === contextMenu.edgeId);
+                if (!edge) return null;
+                const sourceId =
+                  typeof edge.source === "object" ? edge.source.id : (edge.source as string);
+                const targetId =
+                  typeof edge.target === "object" ? edge.target.id : (edge.target as string);
+                const sourceLabel = nodes.find((n) => n.id === sourceId)?.label ?? "";
+                const targetLabel = nodes.find((n) => n.id === targetId)?.label ?? "";
+                const isUndirected = edge.direction === "undirected";
+                const isForward = edge.direction === "directed";
+                const options: { value: EditLinkDirection; label: string; pressed: boolean }[] = [
+                  { value: "undirected", label: "−", pressed: isUndirected },
+                  { value: "forward", label: "→", pressed: isForward },
+                  { value: "backward", label: "←", pressed: false },
+                ];
+                return (
+                  <>
+                    <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs">
+                      <span
+                        className="truncate max-w-[80px]"
+                        title={sourceLabel}
+                        data-testid="edge-menu-source"
+                      >
+                        {sourceLabel}
+                      </span>
+                      <div
+                        role="group"
+                        aria-label="リンクの向き"
+                        className="inline-flex items-center rounded-md border border-border overflow-hidden"
+                      >
+                        {options.map((opt) => (
+                          <button
+                            key={opt.value}
+                            type="button"
+                            aria-pressed={opt.pressed}
+                            data-testid={`edge-direction-${opt.value}`}
+                            onClick={() => handleEditLinkDirection(contextMenu.edgeId, opt.value)}
+                            className={`px-2 py-0.5 leading-none ${
+                              opt.pressed
+                                ? "bg-accent text-accent-foreground"
+                                : "bg-transparent hover:bg-accent/50"
+                            }`}
+                          >
+                            {opt.label}
+                          </button>
+                        ))}
+                      </div>
+                      <span
+                        className="truncate max-w-[80px]"
+                        title={targetLabel}
+                        data-testid="edge-menu-target"
+                      >
+                        {targetLabel}
+                      </span>
+                    </div>
+                    <button
+                      className="w-full text-left px-3 py-1.5 text-sm hover:bg-accent text-destructive"
+                      onClick={() => handleDeleteLink(contextMenu.edgeId)}
+                    >
+                      削除
+                    </button>
+                  </>
+                );
+              })()}
           </div>
         )}
 

--- a/apps/pages/src/features/graph/use-graph-simulation.ts
+++ b/apps/pages/src/features/graph/use-graph-simulation.ts
@@ -8,7 +8,7 @@ import {
   type SimulationNodeDatum,
   type SimulationLinkDatum,
 } from "d3-force";
-import type { GraphData } from "core";
+import type { GraphData, LinkDirection } from "core";
 
 export type SimNode = SimulationNodeDatum & {
   id: string;
@@ -17,6 +17,7 @@ export type SimNode = SimulationNodeDatum & {
 
 export type SimLink = SimulationLinkDatum<SimNode> & {
   id: string;
+  direction: LinkDirection;
 };
 
 export const useGraphSimulation = (
@@ -48,6 +49,7 @@ export const useGraphSimulation = (
         id: e.id,
         source: e.source,
         target: e.target,
+        direction: e.direction,
       }));
 
       const nodesChanged =

--- a/apps/pages/src/features/link-picker/link-picker.tsx
+++ b/apps/pages/src/features/link-picker/link-picker.tsx
@@ -7,13 +7,23 @@ import type { Note } from "core";
 
 type LinkPickerProps = {
   sourceNodeId: string;
+  sourceLabel: string;
   onClose: () => void;
 };
 
-export const LinkPicker = ({ sourceNodeId, onClose }: LinkPickerProps) => {
+type DirectionChoice = "undirected" | "forward" | "backward";
+
+const DIRECTION_OPTIONS: { value: DirectionChoice; label: string; aria: string }[] = [
+  { value: "undirected", label: "−", aria: "無向" },
+  { value: "forward", label: "→", aria: "source から target へ" },
+  { value: "backward", label: "←", aria: "target から source へ" },
+];
+
+export const LinkPicker = ({ sourceNodeId, sourceLabel, onClose }: LinkPickerProps) => {
   const graph = useGraph();
   const [search, setSearch] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [direction, setDirection] = useState<DirectionChoice>("undirected");
   const inputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
 
@@ -28,8 +38,14 @@ export const LinkPicker = ({ sourceNodeId, onClose }: LinkPickerProps) => {
   const filtered = results.filter((note: Note) => note.id !== sourceNodeId);
 
   const createLinkMutation = useMutation({
-    mutationFn: async ({ targetId }: { targetId: string }) =>
-      unwrap(await graph.createLink(sourceNodeId, targetId)),
+    mutationFn: async ({ targetId }: { targetId: string }) => {
+      // For "backward" we flip source/target so the stored link points target → source.
+      if (direction === "backward") {
+        return unwrap(await graph.createLink(targetId, sourceNodeId, "directed"));
+      }
+      const dir = direction === "forward" ? "directed" : "undirected";
+      return unwrap(await graph.createLink(sourceNodeId, targetId, dir));
+    },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.graph });
       onClose();
@@ -60,9 +76,42 @@ export const LinkPicker = ({ sourceNodeId, onClose }: LinkPickerProps) => {
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh]" onClick={onClose}>
       <div
-        className="bg-popover border border-border rounded-lg shadow-xl w-[400px] max-w-[90vw]"
+        className="bg-popover border border-border rounded-lg shadow-xl w-[460px] max-w-[90vw]"
         onClick={(e) => e.stopPropagation()}
       >
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-border">
+          <span
+            className="text-sm font-medium truncate max-w-[160px]"
+            title={sourceLabel}
+            data-testid="link-picker-source"
+          >
+            {sourceLabel}
+          </span>
+          <div
+            role="group"
+            aria-label="リンクの向き"
+            className="inline-flex items-center rounded-md border border-border overflow-hidden"
+          >
+            {DIRECTION_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                aria-label={opt.aria}
+                aria-pressed={direction === opt.value}
+                data-testid={`link-direction-${opt.value}`}
+                onClick={() => setDirection(opt.value)}
+                className={`px-3 py-1 text-sm leading-none ${
+                  direction === opt.value
+                    ? "bg-accent text-accent-foreground"
+                    : "bg-transparent hover:bg-accent/50"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+          <span className="text-sm text-muted-foreground">target</span>
+        </div>
         <input
           ref={inputRef}
           type="text"

--- a/packages/adapter-idb/src/index.ts
+++ b/packages/adapter-idb/src/index.ts
@@ -120,6 +120,14 @@ export const createIdbAdapter = async (config?: IdbAdapterConfig): Promise<Stora
       await tx(s.transaction);
     },
 
+    updateLink: async (id, fields) => {
+      const s = store("links", "readwrite");
+      const existing = (await req(s.get(id))) as Link | undefined;
+      if (!existing) return;
+      s.put({ ...existing, ...fields });
+      await tx(s.transaction);
+    },
+
     deleteLink: async (id) => {
       const s = store("links", "readwrite");
       s.delete(id);

--- a/packages/adapter-idb/src/index.ts
+++ b/packages/adapter-idb/src/index.ts
@@ -106,12 +106,11 @@ export const createIdbAdapter = async (config?: IdbAdapterConfig): Promise<Stora
       return row as Link | undefined;
     },
 
-    findLink: async (sourceId, targetId) => {
+    findLinksBetween: async (aId, bId) => {
       const all: Link[] = await req(store("links", "readonly").getAll());
-      return all.find(
+      return all.filter(
         (l) =>
-          (l.sourceId === sourceId && l.targetId === targetId) ||
-          (l.sourceId === targetId && l.targetId === sourceId),
+          (l.sourceId === aId && l.targetId === bId) || (l.sourceId === bId && l.targetId === aId),
       );
     },
 

--- a/packages/adapter-idb/tests/index.test.ts
+++ b/packages/adapter-idb/tests/index.test.ts
@@ -96,7 +96,12 @@ describe("content", () => {
 });
 
 describe("links", () => {
-  const link = (id: string, sourceId: string, targetId: string) => ({ id, sourceId, targetId });
+  const link = (
+    id: string,
+    sourceId: string,
+    targetId: string,
+    direction: "undirected" | "directed" = "undirected",
+  ) => ({ id, sourceId, targetId, direction });
 
   test("insertLink and getAllLinks", async () => {
     await adapter.insertLink(link("l1", "a", "b"));
@@ -105,26 +110,28 @@ describe("links", () => {
     expect(all).toHaveLength(2);
   });
 
-  test("getLinkById", async () => {
-    await adapter.insertLink(link("l1", "a", "b"));
-    expect(await adapter.getLinkById("l1")).toEqual(link("l1", "a", "b"));
+  test("getLinkById preserves direction", async () => {
+    await adapter.insertLink(link("l1", "a", "b", "directed"));
+    expect(await adapter.getLinkById("l1")).toEqual(link("l1", "a", "b", "directed"));
     expect(await adapter.getLinkById("missing")).toBeUndefined();
   });
 
-  test("findLink forward direction", async () => {
+  test("findLinksBetween returns both orderings", async () => {
     await adapter.insertLink(link("l1", "a", "b"));
-    const found = await adapter.findLink("a", "b");
-    expect(found).toEqual(link("l1", "a", "b"));
+    expect(await adapter.findLinksBetween("a", "b")).toEqual([link("l1", "a", "b")]);
+    expect(await adapter.findLinksBetween("b", "a")).toEqual([link("l1", "a", "b")]);
   });
 
-  test("findLink reverse direction", async () => {
-    await adapter.insertLink(link("l1", "a", "b"));
-    const found = await adapter.findLink("b", "a");
-    expect(found).toEqual(link("l1", "a", "b"));
+  test("findLinksBetween returns multiple directed links between same pair", async () => {
+    await adapter.insertLink(link("l1", "a", "b", "directed"));
+    await adapter.insertLink(link("l2", "b", "a", "directed"));
+    const found = await adapter.findLinksBetween("a", "b");
+    expect(found).toHaveLength(2);
+    expect(found.map((l) => l.id).sort()).toEqual(["l1", "l2"]);
   });
 
-  test("findLink returns undefined when not found", async () => {
-    expect(await adapter.findLink("x", "y")).toBeUndefined();
+  test("findLinksBetween returns empty array when not found", async () => {
+    expect(await adapter.findLinksBetween("x", "y")).toEqual([]);
   });
 
   test("deleteLink", async () => {

--- a/packages/adapter-idb/tests/index.test.ts
+++ b/packages/adapter-idb/tests/index.test.ts
@@ -134,6 +134,17 @@ describe("links", () => {
     expect(await adapter.findLinksBetween("x", "y")).toEqual([]);
   });
 
+  test("updateLink replaces source/target/direction", async () => {
+    await adapter.insertLink(link("l1", "a", "b", "undirected"));
+    await adapter.updateLink("l1", { sourceId: "b", targetId: "a", direction: "directed" });
+    expect(await adapter.getLinkById("l1")).toEqual(link("l1", "b", "a", "directed"));
+  });
+
+  test("updateLink no-ops on missing id", async () => {
+    await adapter.updateLink("missing", { sourceId: "x", targetId: "y", direction: "directed" });
+    expect(await adapter.getLinkById("missing")).toBeUndefined();
+  });
+
   test("deleteLink", async () => {
     await adapter.insertLink(link("l1", "a", "b"));
     await adapter.deleteLink("l1");

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -14,6 +14,7 @@ type LinkRow = {
   id: string;
   source_id: string;
   target_id: string;
+  direction: "undirected" | "directed";
 };
 
 const toNote = (row: NoteRow): Note => ({
@@ -27,6 +28,7 @@ const toLink = (row: LinkRow): Link => ({
   id: row.id,
   sourceId: row.source_id,
   targetId: row.target_id,
+  direction: row.direction,
 });
 
 export type SqliteAdapterConfig = {
@@ -55,11 +57,20 @@ export const createSqliteAdapter = (config: SqliteAdapterConfig): StorageAdapter
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS links (
-      id        TEXT PRIMARY KEY,
-      source_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
-      target_id TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
-      UNIQUE(source_id, target_id)
+      id         TEXT PRIMARY KEY,
+      source_id  TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+      target_id  TEXT NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+      direction  TEXT NOT NULL CHECK (direction IN ('undirected', 'directed')),
+      CHECK (direction = 'directed' OR source_id < target_id)
     )
+  `);
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS links_directed_unique
+      ON links(source_id, target_id) WHERE direction = 'directed'
+  `);
+  db.exec(`
+    CREATE UNIQUE INDEX IF NOT EXISTS links_undirected_unique
+      ON links(source_id, target_id) WHERE direction = 'undirected'
   `);
 
   const notePath = (id: string) => path.join(notesDir, `${id}.md`);
@@ -124,20 +135,21 @@ export const createSqliteAdapter = (config: SqliteAdapterConfig): StorageAdapter
       return row ? toLink(row) : undefined;
     },
 
-    findLink: async (sourceId, targetId) => {
-      const row = db
+    findLinksBetween: async (aId, bId) => {
+      const rows = db
         .prepare(
           "SELECT * FROM links WHERE (source_id = ? AND target_id = ?) OR (source_id = ? AND target_id = ?)",
         )
-        .get(sourceId, targetId, targetId, sourceId) as LinkRow | undefined;
-      return row ? toLink(row) : undefined;
+        .all(aId, bId, bId, aId) as LinkRow[];
+      return rows.map(toLink);
     },
 
     insertLink: async (link) => {
-      db.prepare("INSERT INTO links (id, source_id, target_id) VALUES (?, ?, ?)").run(
+      db.prepare("INSERT INTO links (id, source_id, target_id, direction) VALUES (?, ?, ?, ?)").run(
         link.id,
         link.sourceId,
         link.targetId,
+        link.direction,
       );
     },
 

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -153,6 +153,15 @@ export const createSqliteAdapter = (config: SqliteAdapterConfig): StorageAdapter
       );
     },
 
+    updateLink: async (id, fields) => {
+      db.prepare("UPDATE links SET source_id = ?, target_id = ?, direction = ? WHERE id = ?").run(
+        fields.sourceId,
+        fields.targetId,
+        fields.direction,
+        id,
+      );
+    },
+
     deleteLink: async (id) => {
       db.prepare("DELETE FROM links WHERE id = ?").run(id);
     },

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -16,8 +16,8 @@ export type StorageAdapter = {
   // Links
   getAllLinks: () => Promise<Link[]>;
   getLinkById: (id: string) => Promise<Link | undefined>;
-  /** Checks both directions: (sourceId, targetId) and (targetId, sourceId) */
-  findLink: (sourceId: string, targetId: string) => Promise<Link | undefined>;
+  /** Returns every link between {aId, bId}, regardless of argument order or direction */
+  findLinksBetween: (aId: string, bId: string) => Promise<Link[]>;
   insertLink: (link: Link) => Promise<void>;
   deleteLink: (id: string) => Promise<void>;
 };

--- a/packages/core/src/adapter.ts
+++ b/packages/core/src/adapter.ts
@@ -19,5 +19,9 @@ export type StorageAdapter = {
   /** Returns every link between {aId, bId}, regardless of argument order or direction */
   findLinksBetween: (aId: string, bId: string) => Promise<Link[]>;
   insertLink: (link: Link) => Promise<void>;
+  updateLink: (
+    id: string,
+    fields: { sourceId: string; targetId: string; direction: Link["direction"] },
+  ) => Promise<void>;
   deleteLink: (id: string) => Promise<void>;
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,8 @@ export type {
   CreateNoteError,
   RenameNoteError,
   CreateLinkError,
+  EditLinkDirection,
+  EditLinkError,
 } from "./types.js";
 
 export type { StorageAdapter } from "./adapter.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export type {
   Note,
   NoteWithContent,
   Link,
+  LinkDirection,
   GraphNode,
   GraphEdge,
   GraphData,

--- a/packages/core/src/knowledge-graph.ts
+++ b/packages/core/src/knowledge-graph.ts
@@ -9,6 +9,8 @@ import type {
   CreateNoteError,
   RenameNoteError,
   CreateLinkError,
+  EditLinkDirection,
+  EditLinkError,
 } from "./types.js";
 import { validateTitle } from "./validation.js";
 
@@ -31,6 +33,10 @@ export type KnowledgeGraph = {
     targetId: string,
     direction?: LinkDirection,
   ) => Promise<Result<Link, CreateLinkError>>;
+  updateLinkDirection: (
+    linkId: string,
+    change: EditLinkDirection,
+  ) => Promise<Result<Link, EditLinkError>>;
   deleteLink: (id: string) => Promise<Result<{ ok: true }, "NOT_FOUND">>;
   getGraph: () => Promise<GraphData>;
 };
@@ -146,6 +152,61 @@ export const createKnowledgeGraph = (config: KnowledgeGraphConfig): KnowledgeGra
       await adapter.insertLink(link);
 
       return { ok: true, value: link };
+    },
+
+    updateLinkDirection: async (linkId, change) => {
+      const link = await adapter.getLinkById(linkId);
+      if (!link) return { ok: false, error: "NOT_FOUND" };
+
+      let newSourceId: string;
+      let newTargetId: string;
+      let newDirection: LinkDirection;
+
+      if (change === "undirected") {
+        const lower = link.sourceId < link.targetId ? link.sourceId : link.targetId;
+        const higher = link.sourceId < link.targetId ? link.targetId : link.sourceId;
+        newSourceId = lower;
+        newTargetId = higher;
+        newDirection = "undirected";
+      } else if (change === "forward") {
+        newSourceId = link.sourceId;
+        newTargetId = link.targetId;
+        newDirection = "directed";
+      } else {
+        // backward: flip source/target and store as directed
+        newSourceId = link.targetId;
+        newTargetId = link.sourceId;
+        newDirection = "directed";
+      }
+
+      const unchanged =
+        newSourceId === link.sourceId &&
+        newTargetId === link.targetId &&
+        newDirection === link.direction;
+      if (unchanged) return { ok: true, value: link };
+
+      const between = await adapter.findLinksBetween(newSourceId, newTargetId);
+      const conflict =
+        newDirection === "undirected"
+          ? between.some((l) => l.id !== linkId)
+          : between.some(
+              (l) =>
+                l.id !== linkId &&
+                (l.direction === "undirected" ||
+                  (l.sourceId === newSourceId && l.targetId === newTargetId)),
+            );
+      if (conflict) return { ok: false, error: "DUPLICATE_LINK" };
+
+      await adapter.updateLink(linkId, {
+        sourceId: newSourceId,
+        targetId: newTargetId,
+        direction: newDirection,
+      });
+
+      return {
+        ok: true,
+        value: { ...link, sourceId: newSourceId, targetId: newTargetId, direction: newDirection },
+      };
     },
 
     deleteLink: async (id) => {

--- a/packages/core/src/knowledge-graph.ts
+++ b/packages/core/src/knowledge-graph.ts
@@ -3,6 +3,7 @@ import type {
   Note,
   NoteWithContent,
   Link,
+  LinkDirection,
   GraphData,
   Result,
   CreateNoteError,
@@ -25,7 +26,11 @@ export type KnowledgeGraph = {
   renameNote: (id: string, title: string) => Promise<Result<Note, RenameNoteError>>;
   deleteNote: (id: string) => Promise<Result<{ ok: true }, "NOT_FOUND">>;
   saveContent: (id: string, content: string) => Promise<Result<{ ok: true }, "NOT_FOUND">>;
-  createLink: (sourceId: string, targetId: string) => Promise<Result<Link, CreateLinkError>>;
+  createLink: (
+    sourceId: string,
+    targetId: string,
+    direction?: LinkDirection,
+  ) => Promise<Result<Link, CreateLinkError>>;
   deleteLink: (id: string) => Promise<Result<{ ok: true }, "NOT_FOUND">>;
   getGraph: () => Promise<GraphData>;
 };
@@ -107,7 +112,7 @@ export const createKnowledgeGraph = (config: KnowledgeGraphConfig): KnowledgeGra
       return { ok: true, value: { ok: true as const } };
     },
 
-    createLink: async (sourceId, targetId) => {
+    createLink: async (sourceId, targetId, direction = "undirected") => {
       if (sourceId === targetId) return { ok: false, error: "SELF_LINK" };
 
       const source = await adapter.getNoteById(sourceId);
@@ -116,11 +121,28 @@ export const createKnowledgeGraph = (config: KnowledgeGraphConfig): KnowledgeGra
       const target = await adapter.getNoteById(targetId);
       if (!target) return { ok: false, error: "TARGET_NOT_FOUND" };
 
-      const existing = await adapter.findLink(sourceId, targetId);
-      if (existing) return { ok: false, error: "DUPLICATE_LINK" };
+      const existing = await adapter.findLinksBetween(sourceId, targetId);
+
+      // Undirected and directed links cannot coexist between the same pair.
+      // For a directed insert, an existing same-direction link is a duplicate.
+      const conflict =
+        direction === "undirected"
+          ? existing.length > 0
+          : existing.some(
+              (l) =>
+                l.direction === "undirected" ||
+                (l.sourceId === sourceId && l.targetId === targetId),
+            );
+      if (conflict) return { ok: false, error: "DUPLICATE_LINK" };
+
+      // Canonicalize undirected links so {a, b} always stores with sourceId < targetId.
+      const [s, t] =
+        direction === "undirected" && sourceId > targetId
+          ? [targetId, sourceId]
+          : [sourceId, targetId];
 
       const id = generateId();
-      const link: Link = { id, sourceId, targetId };
+      const link: Link = { id, sourceId: s, targetId: t, direction };
       await adapter.insertLink(link);
 
       return { ok: true, value: link };
@@ -140,7 +162,12 @@ export const createKnowledgeGraph = (config: KnowledgeGraphConfig): KnowledgeGra
 
       return {
         nodes: notes.map((n) => ({ id: n.id, label: n.title })),
-        edges: links.map((l) => ({ id: l.id, source: l.sourceId, target: l.targetId })),
+        edges: links.map((l) => ({
+          id: l.id,
+          source: l.sourceId,
+          target: l.targetId,
+          direction: l.direction,
+        })),
       };
     },
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -44,3 +44,11 @@ export type CreateLinkError =
   | "SOURCE_NOT_FOUND"
   | "TARGET_NOT_FOUND"
   | "DUPLICATE_LINK";
+/**
+ * UI-level link direction change.
+ * - "undirected": make undirected (canonicalize sourceId < targetId)
+ * - "forward": directed in current sourceId → targetId orientation
+ * - "backward": directed in flipped (targetId → sourceId) orientation
+ */
+export type EditLinkDirection = "undirected" | "forward" | "backward";
+export type EditLinkError = "NOT_FOUND" | "DUPLICATE_LINK";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,10 +9,13 @@ export type NoteWithContent = Note & {
   content: string;
 };
 
+export type LinkDirection = "undirected" | "directed";
+
 export type Link = {
   id: string;
   sourceId: string;
   targetId: string;
+  direction: LinkDirection;
 };
 
 export type GraphNode = {
@@ -24,6 +27,7 @@ export type GraphEdge = {
   id: string;
   source: string;
   target: string;
+  direction: LinkDirection;
 };
 
 export type GraphData = {

--- a/packages/core/tests/knowledge-graph.test.ts
+++ b/packages/core/tests/knowledge-graph.test.ts
@@ -43,6 +43,11 @@ const createMemoryAdapter = (): StorageAdapter => {
     insertLink: async (link) => {
       links.set(link.id, link);
     },
+    updateLink: async (id, fields) => {
+      const cur = links.get(id);
+      if (!cur) return;
+      links.set(id, { ...cur, ...fields });
+    },
     deleteLink: async (id) => {
       links.delete(id);
     },
@@ -185,5 +190,99 @@ describe("createLink (direction)", () => {
 
   test("rejects self link", async () => {
     expect(await graph.createLink(aId, aId)).toEqual({ ok: false, error: "SELF_LINK" });
+  });
+});
+
+describe("updateLinkDirection", () => {
+  let graph: ReturnType<typeof createKnowledgeGraph>;
+  let idCounter = 0;
+  let aId: string;
+  let bId: string;
+  let cId: string;
+
+  beforeEach(async () => {
+    idCounter = 0;
+    graph = createKnowledgeGraph({
+      adapter: createMemoryAdapter(),
+      generateId: () => `id-${++idCounter}`,
+      now: () => new Date(2026, 0, idCounter).toISOString(),
+    });
+    const a = await graph.createNote("A");
+    const b = await graph.createNote("B");
+    const c = await graph.createNote("C");
+    if (!a.ok || !b.ok || !c.ok) throw new Error("setup failed");
+    aId = a.value.id;
+    bId = b.value.id;
+    cId = c.value.id;
+  });
+
+  test("forward keeps directed orientation as-is", async () => {
+    const created = await graph.createLink(aId, bId, "directed");
+    if (!created.ok) throw new Error("setup");
+    const result = await graph.updateLinkDirection(created.value.id, "forward");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.direction).toBe("directed");
+    expect(result.value.sourceId).toBe(aId);
+    expect(result.value.targetId).toBe(bId);
+  });
+
+  test("backward flips a directed link", async () => {
+    const created = await graph.createLink(aId, bId, "directed");
+    if (!created.ok) throw new Error("setup");
+    const result = await graph.updateLinkDirection(created.value.id, "backward");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.direction).toBe("directed");
+    expect(result.value.sourceId).toBe(bId);
+    expect(result.value.targetId).toBe(aId);
+  });
+
+  test("undirected canonicalizes from a directed link", async () => {
+    const high = aId < bId ? bId : aId;
+    const low = aId < bId ? aId : bId;
+    const created = await graph.createLink(high, low, "directed");
+    if (!created.ok) throw new Error("setup");
+    const result = await graph.updateLinkDirection(created.value.id, "undirected");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.direction).toBe("undirected");
+    expect(result.value.sourceId).toBe(low);
+    expect(result.value.targetId).toBe(high);
+  });
+
+  test("rejects when conflicting link exists between same pair", async () => {
+    const ab = await graph.createLink(aId, bId, "directed");
+    const ba = await graph.createLink(bId, aId, "directed");
+    if (!ab.ok || !ba.ok) throw new Error("setup");
+    // Trying to make A→B undirected would conflict with the still-existing B→A.
+    const result = await graph.updateLinkDirection(ab.value.id, "undirected");
+    expect(result).toEqual({ ok: false, error: "DUPLICATE_LINK" });
+  });
+
+  test("rejects when flipping would duplicate an existing directed link", async () => {
+    const ab = await graph.createLink(aId, bId, "directed");
+    const ba = await graph.createLink(bId, aId, "directed");
+    if (!ab.ok || !ba.ok) throw new Error("setup");
+    // Flipping A→B to B→A would collide with the existing B→A.
+    const result = await graph.updateLinkDirection(ab.value.id, "backward");
+    expect(result).toEqual({ ok: false, error: "DUPLICATE_LINK" });
+  });
+
+  test("returns NOT_FOUND for unknown link id", async () => {
+    expect(await graph.updateLinkDirection("missing", "forward")).toEqual({
+      ok: false,
+      error: "NOT_FOUND",
+    });
+  });
+
+  test("does not affect unrelated links", async () => {
+    const ab = await graph.createLink(aId, bId, "directed");
+    await graph.createLink(aId, cId, "directed");
+    if (!ab.ok) throw new Error("setup");
+    const result = await graph.updateLinkDirection(ab.value.id, "backward");
+    expect(result.ok).toBe(true);
+    const all = (await graph.getGraph()).edges;
+    expect(all).toHaveLength(2);
   });
 });

--- a/packages/core/tests/knowledge-graph.test.ts
+++ b/packages/core/tests/knowledge-graph.test.ts
@@ -35,11 +35,10 @@ const createMemoryAdapter = (): StorageAdapter => {
     },
     getAllLinks: async () => [...links.values()],
     getLinkById: async (id) => links.get(id),
-    findLink: async (sourceId, targetId) =>
-      [...links.values()].find(
+    findLinksBetween: async (aId, bId) =>
+      [...links.values()].filter(
         (l) =>
-          (l.sourceId === sourceId && l.targetId === targetId) ||
-          (l.sourceId === targetId && l.targetId === sourceId),
+          (l.sourceId === aId && l.targetId === bId) || (l.sourceId === bId && l.targetId === aId),
       ),
     insertLink: async (link) => {
       links.set(link.id, link);
@@ -113,5 +112,78 @@ describe("searchNotes", () => {
   test("returns empty when no note matches", async () => {
     await graph.createNote("TODO");
     expect(await graph.searchNotes("xyz-not-present")).toEqual([]);
+  });
+});
+
+describe("createLink (direction)", () => {
+  let graph: ReturnType<typeof createKnowledgeGraph>;
+  let idCounter = 0;
+  let aId: string;
+  let bId: string;
+
+  beforeEach(async () => {
+    idCounter = 0;
+    graph = createKnowledgeGraph({
+      adapter: createMemoryAdapter(),
+      generateId: () => `id-${++idCounter}`,
+      now: () => new Date(2026, 0, idCounter).toISOString(),
+    });
+    const a = await graph.createNote("A");
+    const b = await graph.createNote("B");
+    if (!a.ok || !b.ok) throw new Error("setup failed");
+    aId = a.value.id;
+    bId = b.value.id;
+  });
+
+  test("defaults to undirected", async () => {
+    const link = await graph.createLink(aId, bId);
+    expect(link.ok && link.value.direction).toBe("undirected");
+  });
+
+  test("creates a directed A→B", async () => {
+    const link = await graph.createLink(aId, bId, "directed");
+    expect(link.ok).toBe(true);
+    if (!link.ok) return;
+    expect(link.value.sourceId).toBe(aId);
+    expect(link.value.targetId).toBe(bId);
+    expect(link.value.direction).toBe("directed");
+  });
+
+  test("undirected canonicalizes sourceId < targetId", async () => {
+    const high = aId < bId ? bId : aId;
+    const low = aId < bId ? aId : bId;
+    const link = await graph.createLink(high, low);
+    expect(link.ok).toBe(true);
+    if (!link.ok) return;
+    expect(link.value.sourceId).toBe(low);
+    expect(link.value.targetId).toBe(high);
+  });
+
+  test("A→B and B→A can coexist as separate directed links", async () => {
+    const ab = await graph.createLink(aId, bId, "directed");
+    const ba = await graph.createLink(bId, aId, "directed");
+    expect(ab.ok && ba.ok).toBe(true);
+  });
+
+  test("rejects same-direction duplicate", async () => {
+    await graph.createLink(aId, bId, "directed");
+    const dup = await graph.createLink(aId, bId, "directed");
+    expect(dup).toEqual({ ok: false, error: "DUPLICATE_LINK" });
+  });
+
+  test("rejects undirected when any link already exists", async () => {
+    await graph.createLink(aId, bId, "directed");
+    const dup = await graph.createLink(aId, bId);
+    expect(dup).toEqual({ ok: false, error: "DUPLICATE_LINK" });
+  });
+
+  test("rejects directed when undirected already exists", async () => {
+    await graph.createLink(aId, bId);
+    const dup = await graph.createLink(aId, bId, "directed");
+    expect(dup).toEqual({ ok: false, error: "DUPLICATE_LINK" });
+  });
+
+  test("rejects self link", async () => {
+    expect(await graph.createLink(aId, aId)).toEqual({ ok: false, error: "SELF_LINK" });
   });
 });


### PR DESCRIPTION
## Summary
- `Link` に `direction: \"undirected\" | \"directed\"` を追加し、3 種のリンク（無向 / A→B / B→A）を扱えるようにした
- 同一ペア間で無向と有向は共存させず、有向は A→B / B→A の二本まで許す（重複ルールはアプリ層で担保、SQLite は部分 UNIQUE INDEX で同方向重複を防止）
- LinkPicker に `−/→/←` トグルを追加。`←` 選択時は内部で source/target を flip して保存し、ストレージ上は `direction = \"directed\"` の一方向リンクとして扱う
- GraphView は `<defs>` の矢頭マーカーで directed エッジのみに矢印を描画。終点はノード半径ぶん短縮して矢頭が円に被らないように調整
- 範囲は `apps/pages` のみ。`apps/web` / `apps/server` は core 型変更に追従するだけで UI 変更なし（`createLink` の `direction` 省略時は無向）

## Test plan
- [x] `vp run checkAll`（lint/fmt/type）
- [x] `vp test`（core: 14 tests / adapter-idb: 16 tests）
- [x] playwright-cli で apps/pages を実機検証
  - 3 ノート（A, B, C）を作成
  - A 右クリック → 「リンクを追加」 → `−` のまま B → 無向 A−B 描画（矢頭なし）
  - A → `→` → C → 有向 A→C 描画（C 側に矢頭）
  - B → `←` → C → 内部で flip され有向 C→B 描画（B 側に矢頭）
  - 同方向で A→C を再追加 → `DUPLICATE_LINK` で拒否（リンク数 3 のまま）

## Out of scope
- マイグレーション（要件通り省略、IndexedDB / SQLite どちらも `dist` 削除前提で破壊的変更）
- 既存エッジの向きを後から編集する右クリックメニュー
- E2E 自動テスト（手動 playwright-cli 検証のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)