### PR TITLE
feat: シード+方向辿りによるサブグラフ抽出機能

### DIFF
--- a/apps/pages/src/features/graph/graph-view.tsx
+++ b/apps/pages/src/features/graph/graph-view.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
-import { Plus, ZoomIn, ZoomOut, Maximize2, X } from "lucide-react";
+import { Plus, ZoomIn, ZoomOut, Maximize2, X, Filter } from "lucide-react";
 import { useGraph } from "../../lib/graph";
 import { unwrap } from "../../lib/unwrap";
 import { queryKeys } from "../../lib/query";
@@ -10,6 +10,8 @@ import type { EditLinkDirection } from "core";
 import { useGraphSimulation, type SimNode, type SimLink } from "./use-graph-simulation";
 import { LinkPicker } from "../../features/link-picker/link-picker";
 import { SearchPalette } from "../../features/search-palette/search-palette";
+import { SubgraphPanel } from "../../features/subgraph/subgraph-panel";
+import { useSubgraphQuery } from "../../features/subgraph/use-subgraph-query";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -45,6 +47,9 @@ export const GraphView = () => {
   const [deleteNodeId, setDeleteNodeId] = useState<string | null>(null);
   const [dragNode, setDragNode] = useState<string | null>(null);
   const [searchPaletteOpen, setSearchPaletteOpen] = useState(false);
+  const [subgraphPanelOpen, setSubgraphPanelOpen] = useState(false);
+
+  const subgraph = useSubgraphQuery();
 
   useDocumentTitle(null);
 
@@ -244,6 +249,22 @@ export const GraphView = () => {
     setContextMenu(null);
   };
 
+  const handleSeedFromNode = (nodeId: string) => {
+    const node = nodes.find((n) => n.id === nodeId);
+    const label = node?.label?.trim();
+    if (!label) return;
+    subgraph.seedFromTitle(label);
+    setSubgraphPanelOpen(true);
+    setContextMenu(null);
+  };
+
+  // Subgraph filter state — derived once per render so the link/node loops can branch cheaply.
+  const subgraphActive = subgraph.result !== null;
+  const matchedNodeIds = subgraph.result?.nodeIds;
+  const matchedEdgeIds = subgraph.result?.edgeIds;
+  const isFilterMode = subgraphActive && subgraph.displayMode === "filter";
+  const isHighlightMode = subgraphActive && subgraph.displayMode === "highlight";
+
   const handleWheel = useCallback((e: WheelEvent) => {
     e.preventDefault();
     const delta = e.deltaY > 0 ? 0.9 : 1.1;
@@ -402,7 +423,10 @@ export const GraphView = () => {
           </defs>
           <g transform={`translate(${transform.x},${transform.y}) scale(${transform.scale})`}>
             {links.map((link) => {
+              const matched = !subgraphActive || matchedEdgeIds?.has(link.id) === true;
+              if (isFilterMode && !matched) return null;
               const coords = getLinkCoords(link);
+              const opacity = isHighlightMode && !matched ? 0.15 : 1;
               return (
                 <line
                   key={link.id}
@@ -412,6 +436,7 @@ export const GraphView = () => {
                   y2={coords.y2}
                   stroke="#94a3b8"
                   strokeWidth={2}
+                  opacity={opacity}
                   markerEnd={link.direction === "directed" ? "url(#graph-arrow)" : undefined}
                   data-direction={link.direction}
                   className="cursor-pointer"
@@ -426,47 +451,53 @@ export const GraphView = () => {
                 />
               );
             })}
-            {nodes.map((node) => (
-              <g
-                key={node.id}
-                transform={`translate(${node.x ?? 0},${node.y ?? 0})`}
-                className="cursor-pointer"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleNodeClick(node.id);
-                }}
-                onContextMenu={(e) =>
-                  handleContextMenu(e, {
-                    type: "node",
-                    nodeId: node.id,
-                    x: e.clientX,
-                    y: e.clientY,
-                  })
-                }
-                onMouseDown={(e) => {
-                  if (e.button === 0) {
+            {nodes.map((node) => {
+              const matched = !subgraphActive || matchedNodeIds?.has(node.id) === true;
+              if (isFilterMode && !matched) return null;
+              const opacity = isHighlightMode && !matched ? 0.15 : 1;
+              return (
+                <g
+                  key={node.id}
+                  transform={`translate(${node.x ?? 0},${node.y ?? 0})`}
+                  opacity={opacity}
+                  className="cursor-pointer"
+                  onClick={(e) => {
                     e.stopPropagation();
-                    setDragNode(node.id);
-                    const n = nodesRef.current.find((n) => n.id === node.id);
-                    if (n) {
-                      n.fx = n.x;
-                      n.fy = n.y;
-                    }
+                    handleNodeClick(node.id);
+                  }}
+                  onContextMenu={(e) =>
+                    handleContextMenu(e, {
+                      type: "node",
+                      nodeId: node.id,
+                      x: e.clientX,
+                      y: e.clientY,
+                    })
                   }
-                }}
-              >
-                <circle r={NODE_RADIUS} fill="#3b82f6" stroke="#1d4ed8" strokeWidth={2} />
-                <text
-                  dy={-28}
-                  textAnchor="middle"
-                  fontSize={12}
-                  fill="#1e293b"
-                  className="pointer-events-none select-none"
+                  onMouseDown={(e) => {
+                    if (e.button === 0) {
+                      e.stopPropagation();
+                      setDragNode(node.id);
+                      const n = nodesRef.current.find((n) => n.id === node.id);
+                      if (n) {
+                        n.fx = n.x;
+                        n.fy = n.y;
+                      }
+                    }
+                  }}
                 >
-                  {node.label}
-                </text>
-              </g>
-            ))}
+                  <circle r={NODE_RADIUS} fill="#3b82f6" stroke="#1d4ed8" strokeWidth={2} />
+                  <text
+                    dy={-28}
+                    textAnchor="middle"
+                    fontSize={12}
+                    fill="#1e293b"
+                    className="pointer-events-none select-none"
+                  >
+                    {node.label}
+                  </text>
+                </g>
+              );
+            })}
           </g>
         </svg>
 
@@ -484,6 +515,13 @@ export const GraphView = () => {
                   onClick={() => handleAddLink(contextMenu.nodeId)}
                 >
                   リンクを追加
+                </button>
+                <button
+                  className="w-full text-left px-3 py-1.5 text-sm hover:bg-accent"
+                  onClick={() => handleSeedFromNode(contextMenu.nodeId)}
+                  data-testid="node-menu-seed-subgraph"
+                >
+                  このノートをシードに
                 </button>
                 <button
                   className="w-full text-left px-3 py-1.5 text-sm hover:bg-accent text-destructive"
@@ -574,11 +612,39 @@ export const GraphView = () => {
         {/* Search Palette (Cmd+K / Ctrl+K) */}
         {searchPaletteOpen && <SearchPalette onClose={() => setSearchPaletteOpen(false)} />}
 
+        {/* Subgraph extraction panel */}
+        {subgraphPanelOpen && (
+          <SubgraphPanel
+            query={subgraph.query}
+            result={subgraph.result}
+            displayMode={subgraph.displayMode}
+            updateSource={subgraph.updateSource}
+            addSource={subgraph.addSource}
+            removeSource={subgraph.removeSource}
+            updateOp={subgraph.updateOp}
+            setDisplayMode={subgraph.setDisplayMode}
+            clear={subgraph.clear}
+            onClose={() => setSubgraphPanelOpen(false)}
+          />
+        )}
+
         {/* Zoom / Fit-to-view controls */}
         <div
           className="absolute bottom-6 left-6 z-40 flex flex-col rounded-md border border-border bg-popover shadow-md"
           onClick={(e) => e.stopPropagation()}
         >
+          <button
+            type="button"
+            aria-label="サブグラフ抽出"
+            title="サブグラフ抽出"
+            data-testid="subgraph-open"
+            className={`flex h-9 w-9 items-center justify-center border-b border-border hover:bg-accent ${
+              subgraphActive ? "text-primary" : "text-foreground"
+            }`}
+            onClick={() => setSubgraphPanelOpen((v) => !v)}
+          >
+            <Filter size={16} />
+          </button>
           <button
             type="button"
             aria-label="拡大"

--- a/apps/pages/src/features/subgraph/subgraph-panel.tsx
+++ b/apps/pages/src/features/subgraph/subgraph-panel.tsx
@@ -1,0 +1,319 @@
+import { useEffect } from "react";
+import { Plus, Trash2, X } from "lucide-react";
+import type {
+  SetOp,
+  SubgraphQuery,
+  SubgraphResult,
+  SubgraphSource,
+  TraversalDirection,
+} from "core";
+import type { DisplayMode } from "./use-subgraph-query";
+
+type SubgraphPanelProps = {
+  query: SubgraphQuery;
+  result: SubgraphResult | null;
+  displayMode: DisplayMode;
+  updateSource: (index: number, patch: Partial<SubgraphSource>) => void;
+  addSource: (op?: SetOp) => void;
+  removeSource: (index: number) => void;
+  updateOp: (opIndex: number, op: SetOp) => void;
+  setDisplayMode: (mode: DisplayMode) => void;
+  clear: () => void;
+  onClose: () => void;
+};
+
+const DIRECTION_OPTIONS: { value: TraversalDirection; label: string; aria: string }[] = [
+  { value: "outgoing", label: "→", aria: "outgoing" },
+  { value: "incoming", label: "←", aria: "incoming" },
+  { value: "both", label: "↔", aria: "both" },
+];
+
+const SET_OP_OPTIONS: { value: SetOp; label: string; aria: string }[] = [
+  { value: "union", label: "∪", aria: "和集合" },
+  { value: "intersect", label: "∩", aria: "積集合" },
+  { value: "difference", label: "\\", aria: "差集合" },
+];
+
+const DisplayModeToggle = ({
+  mode,
+  onChange,
+}: {
+  mode: DisplayMode;
+  onChange: (mode: DisplayMode) => void;
+}) => (
+  <div
+    role="group"
+    aria-label="表示モード"
+    className="inline-flex items-center rounded-md border border-border overflow-hidden text-xs"
+  >
+    {(["highlight", "filter"] as const).map((m) => (
+      <button
+        key={m}
+        type="button"
+        aria-pressed={mode === m}
+        data-testid={`subgraph-display-${m}`}
+        onClick={() => onChange(m)}
+        className={`px-3 py-1 leading-none ${
+          mode === m
+            ? "bg-accent text-accent-foreground"
+            : "bg-transparent hover:bg-accent/50 text-muted-foreground"
+        }`}
+      >
+        {m === "highlight" ? "ハイライト" : "絞り込み"}
+      </button>
+    ))}
+  </div>
+);
+
+const DirectionPicker = ({
+  value,
+  onChange,
+}: {
+  value: TraversalDirection;
+  onChange: (value: TraversalDirection) => void;
+}) => (
+  <div
+    role="group"
+    aria-label="辿る方向"
+    className="inline-flex items-center rounded-md border border-border overflow-hidden text-sm"
+  >
+    {DIRECTION_OPTIONS.map((opt) => (
+      <button
+        key={opt.value}
+        type="button"
+        aria-label={opt.aria}
+        aria-pressed={value === opt.value}
+        data-testid={`subgraph-direction-${opt.value}`}
+        onClick={() => onChange(opt.value)}
+        className={`px-2 py-0.5 leading-none ${
+          value === opt.value
+            ? "bg-accent text-accent-foreground"
+            : "bg-transparent hover:bg-accent/50"
+        }`}
+      >
+        {opt.label}
+      </button>
+    ))}
+  </div>
+);
+
+const SetOpPicker = ({ value, onChange }: { value: SetOp; onChange: (value: SetOp) => void }) => (
+  <div
+    role="group"
+    aria-label="集合演算"
+    className="inline-flex items-center rounded-md border border-border overflow-hidden text-sm"
+  >
+    {SET_OP_OPTIONS.map((opt) => (
+      <button
+        key={opt.value}
+        type="button"
+        aria-label={opt.aria}
+        aria-pressed={value === opt.value}
+        data-testid={`subgraph-op-${opt.value}`}
+        onClick={() => onChange(opt.value)}
+        className={`px-2 py-0.5 leading-none ${
+          value === opt.value
+            ? "bg-accent text-accent-foreground"
+            : "bg-transparent hover:bg-accent/50"
+        }`}
+      >
+        {opt.label}
+      </button>
+    ))}
+  </div>
+);
+
+const SourceCard = ({
+  index,
+  source,
+  canRemove,
+  onUpdate,
+  onRemove,
+}: {
+  index: number;
+  source: SubgraphSource;
+  canRemove: boolean;
+  onUpdate: (patch: Partial<SubgraphSource>) => void;
+  onRemove: () => void;
+}) => {
+  const unlimited = source.maxHops === undefined;
+  return (
+    <div className="rounded-md border border-border p-2 space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-muted-foreground">シード {index + 1}</span>
+        {canRemove && (
+          <button
+            type="button"
+            aria-label="このシードグループを削除"
+            className="p-1 rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+            onClick={onRemove}
+          >
+            <Trash2 size={12} />
+          </button>
+        )}
+      </div>
+
+      <textarea
+        value={source.seedTitles.join("\n")}
+        onChange={(e) => {
+          const lines = e.target.value.split("\n");
+          onUpdate({ seedTitles: lines });
+        }}
+        placeholder="ノートのタイトル（1行に1つ）"
+        rows={Math.min(Math.max(source.seedTitles.length, 1), 4)}
+        data-testid={`subgraph-seed-textarea-${index}`}
+        className="w-full px-2 py-1.5 text-sm bg-transparent border border-border rounded-sm outline-none focus:ring-1 focus:ring-ring resize-y"
+      />
+
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-muted-foreground w-10">方向</span>
+        <DirectionPicker
+          value={source.direction}
+          onChange={(direction) => onUpdate({ direction })}
+        />
+      </div>
+
+      <div className="flex items-center gap-2 text-xs">
+        <span className="text-muted-foreground w-10">深さ</span>
+        <input
+          type="number"
+          min={1}
+          value={unlimited ? "" : source.maxHops}
+          disabled={unlimited}
+          onChange={(e) => {
+            const v = e.target.value;
+            const n = v === "" ? undefined : Math.max(1, Number(v));
+            onUpdate({ maxHops: n });
+          }}
+          data-testid={`subgraph-hops-${index}`}
+          className="w-16 px-2 py-0.5 bg-transparent border border-border rounded-sm outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
+        />
+        <label className="flex items-center gap-1 select-none">
+          <input
+            type="checkbox"
+            checked={unlimited}
+            onChange={(e) => onUpdate({ maxHops: e.target.checked ? undefined : 1 })}
+            data-testid={`subgraph-unlimited-${index}`}
+          />
+          <span>無制限</span>
+        </label>
+      </div>
+
+      <label className="flex items-center gap-1 text-xs select-none">
+        <input
+          type="checkbox"
+          checked={source.leavesOnly ?? false}
+          onChange={(e) => onUpdate({ leavesOnly: e.target.checked })}
+          data-testid={`subgraph-leaves-${index}`}
+        />
+        <span>葉のみ（有向リンクで out-degree 0）</span>
+      </label>
+    </div>
+  );
+};
+
+export const SubgraphPanel = ({
+  query,
+  result,
+  displayMode,
+  updateSource,
+  addSource,
+  removeSource,
+  updateOp,
+  setDisplayMode,
+  clear,
+  onClose,
+}: SubgraphPanelProps) => {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+
+  return (
+    <div
+      className="absolute top-6 right-6 z-40 w-[360px] max-h-[calc(100vh-3rem)] flex flex-col rounded-md border border-border bg-popover shadow-md"
+      onClick={(e) => e.stopPropagation()}
+      data-testid="subgraph-panel"
+    >
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+        <span className="text-sm font-medium">サブグラフ抽出</span>
+        <button
+          type="button"
+          aria-label="パネルを閉じる"
+          className="p-1 rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground"
+          onClick={onClose}
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {query.sources.map((source, i) => (
+          <div key={i} className="space-y-2">
+            {i > 0 && (
+              <div className="flex items-center gap-2 text-xs">
+                <span className="text-muted-foreground w-10">演算</span>
+                <SetOpPicker
+                  value={query.ops[i - 1] ?? "union"}
+                  onChange={(op) => updateOp(i - 1, op)}
+                />
+              </div>
+            )}
+            <SourceCard
+              index={i}
+              source={source}
+              canRemove={query.sources.length > 1}
+              onUpdate={(patch) => updateSource(i, patch)}
+              onRemove={() => removeSource(i)}
+            />
+          </div>
+        ))}
+
+        <button
+          type="button"
+          className="w-full flex items-center justify-center gap-1 px-2 py-1.5 text-xs text-muted-foreground border border-dashed border-border rounded-md hover:bg-accent hover:text-foreground"
+          onClick={() => addSource()}
+          data-testid="subgraph-add-source"
+        >
+          <Plus size={12} />
+          シードグループを追加
+        </button>
+      </div>
+
+      <div className="border-t border-border p-3 space-y-2">
+        {result ? (
+          <div className="text-xs text-muted-foreground" data-testid="subgraph-result-summary">
+            {result.nodeIds.size} ノード / {result.edgeIds.size} エッジ
+          </div>
+        ) : (
+          <div className="text-xs text-muted-foreground">タイトルを入力すると抽出されます</div>
+        )}
+
+        {result && result.unresolvedTitles.length > 0 && (
+          <div
+            className="text-xs text-destructive"
+            data-testid="subgraph-unresolved-warning"
+            role="status"
+          >
+            未解決: {result.unresolvedTitles.map((t) => `"${t}"`).join(", ")}
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-2">
+          <DisplayModeToggle mode={displayMode} onChange={setDisplayMode} />
+          <button
+            type="button"
+            className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+            onClick={clear}
+            data-testid="subgraph-clear"
+          >
+            クリア
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/pages/src/features/subgraph/use-subgraph-query.ts
+++ b/apps/pages/src/features/subgraph/use-subgraph-query.ts
@@ -1,0 +1,101 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { evaluateSubgraph } from "core";
+import type { SetOp, SubgraphQuery, SubgraphResult, SubgraphSource } from "core";
+import { useGraph } from "../../lib/graph";
+import { queryKeys } from "../../lib/query";
+
+export type DisplayMode = "highlight" | "filter";
+
+const emptySource = (): SubgraphSource => ({
+  seedTitles: [],
+  direction: "outgoing",
+  maxHops: undefined,
+  leavesOnly: false,
+});
+
+const initialQuery = (): SubgraphQuery => ({
+  sources: [emptySource()],
+  ops: [],
+});
+
+const isQueryActive = (query: SubgraphQuery): boolean =>
+  query.sources.some((s) => s.seedTitles.some((t) => t.trim().length > 0));
+
+export const useSubgraphQuery = () => {
+  const graph = useGraph();
+  const [query, setQuery] = useState<SubgraphQuery>(initialQuery);
+  const [displayMode, setDisplayMode] = useState<DisplayMode>("highlight");
+
+  const { data: graphData } = useQuery({
+    queryKey: queryKeys.graph,
+    queryFn: () => graph.getGraph(),
+  });
+
+  const result = useMemo<SubgraphResult | null>(() => {
+    if (!graphData || !isQueryActive(query)) return null;
+    return evaluateSubgraph(graphData, query);
+  }, [graphData, query]);
+
+  const updateSource = useCallback((index: number, patch: Partial<SubgraphSource>) => {
+    setQuery((q) => ({
+      ...q,
+      sources: q.sources.map((s, i) => (i === index ? { ...s, ...patch } : s)),
+    }));
+  }, []);
+
+  const addSource = useCallback((op: SetOp = "union") => {
+    setQuery((q) => ({
+      sources: [...q.sources, emptySource()],
+      ops: [...q.ops, op],
+    }));
+  }, []);
+
+  const removeSource = useCallback((index: number) => {
+    setQuery((q) => {
+      if (q.sources.length <= 1) return q;
+      const sources = q.sources.filter((_, i) => i !== index);
+      const opIndex = index === 0 ? 0 : index - 1;
+      const ops = q.ops.filter((_, i) => i !== opIndex);
+      return { sources, ops };
+    });
+  }, []);
+
+  const updateOp = useCallback((opIndex: number, op: SetOp) => {
+    setQuery((q) => ({
+      ...q,
+      ops: q.ops.map((o, i) => (i === opIndex ? op : o)),
+    }));
+  }, []);
+
+  // Append a title to the first source's seed list (dedupe). Used by GraphView right-click menu.
+  const seedFromTitle = useCallback((title: string) => {
+    setQuery((q) => {
+      const first = q.sources[0] ?? emptySource();
+      const seedTitles = first.seedTitles.includes(title)
+        ? first.seedTitles
+        : [...first.seedTitles, title];
+      const updated: SubgraphSource = { ...first, seedTitles };
+      return { ...q, sources: [updated, ...q.sources.slice(1)] };
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    setQuery(initialQuery());
+  }, []);
+
+  return {
+    query,
+    displayMode,
+    setDisplayMode,
+    result,
+    updateSource,
+    addSource,
+    removeSource,
+    updateOp,
+    seedFromTitle,
+    clear,
+  };
+};
+
+export type UseSubgraphQuery = ReturnType<typeof useSubgraphQuery>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,3 +20,12 @@ export { validateTitle } from "./validation.js";
 
 export { createKnowledgeGraph } from "./knowledge-graph.js";
 export type { KnowledgeGraph, KnowledgeGraphConfig } from "./knowledge-graph.js";
+
+export { evaluateSubgraph } from "./subgraph.js";
+export type {
+  TraversalDirection,
+  SubgraphSource,
+  SetOp,
+  SubgraphQuery,
+  SubgraphResult,
+} from "./subgraph.js";

--- a/packages/core/src/subgraph.ts
+++ b/packages/core/src/subgraph.ts
@@ -1,0 +1,186 @@
+import type { GraphData, GraphEdge } from "./types.js";
+
+export type TraversalDirection = "outgoing" | "incoming" | "both";
+
+export type SubgraphSource = {
+  seedTitles: string[];
+  direction: TraversalDirection;
+  /** undefined = 葉まで（無制限）。0 以上なら N ホップで打ち切り。 */
+  maxHops?: number;
+  /** 有向リンクで out-degree 0 のノードのみ残す。無向リンクは判定に含めない。 */
+  leavesOnly?: boolean;
+};
+
+export type SetOp = "union" | "intersect" | "difference";
+
+/** sources を左から二項で畳み込む。`ops.length === sources.length - 1` を期待。 */
+export type SubgraphQuery = {
+  sources: SubgraphSource[];
+  ops: SetOp[];
+};
+
+export type SubgraphResult = {
+  nodeIds: Set<string>;
+  edgeIds: Set<string>;
+  unresolvedTitles: string[];
+};
+
+const buildTitleIndex = (graph: GraphData): Map<string, string[]> => {
+  const map = new Map<string, string[]>();
+  for (const node of graph.nodes) {
+    const list = map.get(node.label);
+    if (list) list.push(node.id);
+    else map.set(node.label, [node.id]);
+  }
+  return map;
+};
+
+const resolveSeeds = (
+  titles: string[],
+  index: Map<string, string[]>,
+): { ids: Set<string>; unresolved: string[] } => {
+  const ids = new Set<string>();
+  const unresolved: string[] = [];
+  for (const raw of titles) {
+    const title = raw.trim();
+    if (title.length === 0) continue;
+    const hits = index.get(title);
+    if (!hits || hits.length === 0) {
+      unresolved.push(title);
+      continue;
+    }
+    for (const id of hits) ids.add(id);
+  }
+  return { ids, unresolved };
+};
+
+// Undirected edges are always traversed bidirectionally regardless of the chosen direction.
+const stepNeighbors = (
+  frontier: Set<string>,
+  edges: GraphEdge[],
+  direction: TraversalDirection,
+): Set<string> => {
+  const next = new Set<string>();
+  for (const e of edges) {
+    if (e.direction === "undirected") {
+      if (frontier.has(e.source)) next.add(e.target);
+      if (frontier.has(e.target)) next.add(e.source);
+      continue;
+    }
+    if (direction === "outgoing" || direction === "both") {
+      if (frontier.has(e.source)) next.add(e.target);
+    }
+    if (direction === "incoming" || direction === "both") {
+      if (frontier.has(e.target)) next.add(e.source);
+    }
+  }
+  return next;
+};
+
+const expand = (
+  seeds: Set<string>,
+  edges: GraphEdge[],
+  direction: TraversalDirection,
+  maxHops: number | undefined,
+): Set<string> => {
+  const visited = new Set(seeds);
+  let frontier = new Set(seeds);
+  let hops = 0;
+  while (frontier.size > 0 && (maxHops === undefined || hops < maxHops)) {
+    const next = stepNeighbors(frontier, edges, direction);
+    const fresh = new Set<string>();
+    for (const id of next) {
+      if (!visited.has(id)) {
+        visited.add(id);
+        fresh.add(id);
+      }
+    }
+    frontier = fresh;
+    hops += 1;
+  }
+  return visited;
+};
+
+const isGlobalLeaf = (id: string, edges: GraphEdge[]): boolean => {
+  for (const e of edges) {
+    if (e.direction === "directed" && e.source === id) return false;
+  }
+  return true;
+};
+
+const filterLeaves = (nodes: Set<string>, edges: GraphEdge[]): Set<string> => {
+  const out = new Set<string>();
+  for (const id of nodes) {
+    if (isGlobalLeaf(id, edges)) out.add(id);
+  }
+  return out;
+};
+
+const evaluateSource = (
+  source: SubgraphSource,
+  graph: GraphData,
+  titleIndex: Map<string, string[]>,
+): { ids: Set<string>; unresolved: string[] } => {
+  const { ids: seeds, unresolved } = resolveSeeds(source.seedTitles, titleIndex);
+  if (seeds.size === 0) return { ids: new Set(), unresolved };
+  const expanded = expand(seeds, graph.edges, source.direction, source.maxHops);
+  const filtered = source.leavesOnly ? filterLeaves(expanded, graph.edges) : expanded;
+  return { ids: filtered, unresolved };
+};
+
+const applyOp = (a: Set<string>, b: Set<string>, op: SetOp): Set<string> => {
+  if (op === "union") {
+    const out = new Set(a);
+    for (const id of b) out.add(id);
+    return out;
+  }
+  if (op === "intersect") {
+    const out = new Set<string>();
+    for (const id of a) if (b.has(id)) out.add(id);
+    return out;
+  }
+  const out = new Set(a);
+  for (const id of b) out.delete(id);
+  return out;
+};
+
+const dedupePreserveOrder = (items: string[]): string[] => {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of items) {
+    if (seen.has(item)) continue;
+    seen.add(item);
+    out.push(item);
+  }
+  return out;
+};
+
+export const evaluateSubgraph = (graph: GraphData, query: SubgraphQuery): SubgraphResult => {
+  if (query.sources.length === 0) {
+    return { nodeIds: new Set(), edgeIds: new Set(), unresolvedTitles: [] };
+  }
+
+  const titleIndex = buildTitleIndex(graph);
+  const unresolvedAll: string[] = [];
+  const sourceResults: Set<string>[] = [];
+  for (const source of query.sources) {
+    const r = evaluateSource(source, graph, titleIndex);
+    unresolvedAll.push(...r.unresolved);
+    sourceResults.push(r.ids);
+  }
+
+  let nodeIds = new Set<string>(sourceResults[0] ?? []);
+  for (let i = 1; i < sourceResults.length; i += 1) {
+    const next = sourceResults[i];
+    if (!next) continue;
+    const op = query.ops[i - 1] ?? "union";
+    nodeIds = applyOp(nodeIds, next, op);
+  }
+
+  const edgeIds = new Set<string>();
+  for (const e of graph.edges) {
+    if (nodeIds.has(e.source) && nodeIds.has(e.target)) edgeIds.add(e.id);
+  }
+
+  return { nodeIds, edgeIds, unresolvedTitles: dedupePreserveOrder(unresolvedAll) };
+};

--- a/packages/core/tests/subgraph.test.ts
+++ b/packages/core/tests/subgraph.test.ts
@@ -1,0 +1,305 @@
+import { describe, test, expect } from "vite-plus/test";
+import { evaluateSubgraph } from "../src/subgraph.ts";
+import type { GraphData, GraphEdge } from "../src/index.ts";
+
+const buildGraph = (nodeMap: Record<string, string>, edges: GraphEdge[]): GraphData => ({
+  nodes: Object.entries(nodeMap).map(([id, label]) => ({ id, label })),
+  edges,
+});
+
+const directedEdge = (id: string, source: string, target: string): GraphEdge => ({
+  id,
+  source,
+  target,
+  direction: "directed",
+});
+
+const undirectedEdge = (id: string, source: string, target: string): GraphEdge => ({
+  id,
+  source,
+  target,
+  direction: "undirected",
+});
+
+describe("evaluateSubgraph - traversal", () => {
+  test("outgoing one hop returns direct successors only", () => {
+    const graph = buildGraph({ A: "A", B: "B", C: "C", D: "D" }, [
+      directedEdge("e1", "A", "B"),
+      directedEdge("e2", "B", "C"),
+      directedEdge("e3", "C", "D"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["A"], direction: "outgoing", maxHops: 1 }],
+      ops: [],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["A", "B"]);
+    expect([...result.edgeIds].sort()).toEqual(["e1"]);
+  });
+
+  test("outgoing unlimited reaches all descendants", () => {
+    const graph = buildGraph({ A: "A", B: "B", C: "C", D: "D" }, [
+      directedEdge("e1", "A", "B"),
+      directedEdge("e2", "B", "C"),
+      directedEdge("e3", "C", "D"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["A"], direction: "outgoing" }],
+      ops: [],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["A", "B", "C", "D"]);
+    expect([...result.edgeIds].sort()).toEqual(["e1", "e2", "e3"]);
+  });
+
+  test("incoming reaches predecessors", () => {
+    const graph = buildGraph({ A: "A", B: "B", C: "C", X: "X" }, [
+      directedEdge("e1", "A", "B"),
+      directedEdge("e2", "B", "C"),
+      directedEdge("e3", "X", "C"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["C"], direction: "incoming" }],
+      ops: [],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["A", "B", "C", "X"]);
+  });
+
+  test("both follows directed edges in either direction", () => {
+    const graph = buildGraph({ A: "A", B: "B", C: "C" }, [
+      directedEdge("e1", "A", "B"),
+      directedEdge("e2", "B", "C"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["B"], direction: "both" }],
+      ops: [],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["A", "B", "C"]);
+  });
+
+  test("undirected edge is bidirectional even in outgoing mode", () => {
+    const graph = buildGraph({ A: "A", B: "B", C: "C" }, [
+      undirectedEdge("e1", "A", "B"),
+      directedEdge("e2", "B", "C"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["A"], direction: "outgoing" }],
+      ops: [],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["A", "B", "C"]);
+  });
+
+  test("respects maxHops", () => {
+    const graph = buildGraph({ A: "A", B: "B", C: "C", D: "D" }, [
+      directedEdge("e1", "A", "B"),
+      directedEdge("e2", "B", "C"),
+      directedEdge("e3", "C", "D"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["A"], direction: "outgoing", maxHops: 2 }],
+      ops: [],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["A", "B", "C"]);
+  });
+
+  test("handles cycles without infinite loop", () => {
+    const graph = buildGraph({ A: "A", B: "B", C: "C" }, [
+      directedEdge("e1", "A", "B"),
+      directedEdge("e2", "B", "C"),
+      directedEdge("e3", "C", "A"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["A"], direction: "outgoing" }],
+      ops: [],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["A", "B", "C"]);
+  });
+});
+
+describe("evaluateSubgraph - leaves", () => {
+  test("leavesOnly keeps only nodes with no outgoing directed edges", () => {
+    // Project -> Task1 -> SubA; Project -> Task2; Task1 -> SubB
+    const graph = buildGraph({ p: "Project", t1: "Task1", t2: "Task2", a: "SubA", b: "SubB" }, [
+      directedEdge("e1", "p", "t1"),
+      directedEdge("e2", "p", "t2"),
+      directedEdge("e3", "t1", "a"),
+      directedEdge("e4", "t1", "b"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["Project"], direction: "outgoing", leavesOnly: true }],
+      ops: [],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["a", "b", "t2"]);
+  });
+
+  test("undirected outgoing edges do not disqualify a node from being a leaf", () => {
+    // P -> Y (directed); X -- Y (undirected)
+    const graph = buildGraph({ p: "Project", x: "X", y: "Y" }, [
+      directedEdge("e1", "p", "y"),
+      undirectedEdge("e2", "x", "y"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["Project"], direction: "outgoing", leavesOnly: true }],
+      ops: [],
+    });
+    // Reachable = {p, y, x}. Global leaves (no directed out) = {y, x}. Project has directed out → not leaf.
+    expect([...result.nodeIds].sort()).toEqual(["x", "y"]);
+  });
+
+  test("leavesOnly + maxHops is intersection of in-range and global leaves", () => {
+    // P -> A -> B -> C
+    const graph = buildGraph({ p: "P", a: "A", b: "B", c: "C" }, [
+      directedEdge("e1", "p", "a"),
+      directedEdge("e2", "a", "b"),
+      directedEdge("e3", "b", "c"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["P"], direction: "outgoing", maxHops: 2, leavesOnly: true }],
+      ops: [],
+    });
+    // Range = {p, a, b}. Global leaves = {c}. Intersection = empty.
+    expect([...result.nodeIds]).toEqual([]);
+  });
+
+  test("isolated seed node is itself a leaf", () => {
+    const graph = buildGraph({ l: "Lonely" }, []);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["Lonely"], direction: "outgoing", leavesOnly: true }],
+      ops: [],
+    });
+    expect([...result.nodeIds]).toEqual(["l"]);
+  });
+});
+
+describe("evaluateSubgraph - set ops", () => {
+  // P1 -> A; P1 -> B; P2 -> B; P2 -> C
+  const graph = buildGraph({ p1: "P1", p2: "P2", a: "A", b: "B", c: "C" }, [
+    directedEdge("e1", "p1", "a"),
+    directedEdge("e2", "p1", "b"),
+    directedEdge("e3", "p2", "b"),
+    directedEdge("e4", "p2", "c"),
+  ]);
+
+  test("union", () => {
+    const result = evaluateSubgraph(graph, {
+      sources: [
+        { seedTitles: ["P1"], direction: "outgoing" },
+        { seedTitles: ["P2"], direction: "outgoing" },
+      ],
+      ops: ["union"],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["a", "b", "c", "p1", "p2"]);
+  });
+
+  test("intersect", () => {
+    const result = evaluateSubgraph(graph, {
+      sources: [
+        { seedTitles: ["P1"], direction: "outgoing" },
+        { seedTitles: ["P2"], direction: "outgoing" },
+      ],
+      ops: ["intersect"],
+    });
+    expect([...result.nodeIds]).toEqual(["b"]);
+  });
+
+  test("difference", () => {
+    const result = evaluateSubgraph(graph, {
+      sources: [
+        { seedTitles: ["P1"], direction: "outgoing" },
+        { seedTitles: ["P2"], direction: "outgoing" },
+      ],
+      ops: ["difference"],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["a", "p1"]);
+  });
+
+  test("left-fold of three sources: (P1 ∪ P2) ∩ A", () => {
+    const result = evaluateSubgraph(graph, {
+      sources: [
+        { seedTitles: ["P1"], direction: "outgoing" },
+        { seedTitles: ["P2"], direction: "outgoing" },
+        { seedTitles: ["A"], direction: "outgoing" },
+      ],
+      ops: ["union", "intersect"],
+    });
+    expect([...result.nodeIds]).toEqual(["a"]);
+  });
+});
+
+describe("evaluateSubgraph - title resolution", () => {
+  test("unresolved titles are reported", () => {
+    const graph = buildGraph({ a: "A" }, []);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["A", "Missing"], direction: "outgoing" }],
+      ops: [],
+    });
+    expect(result.unresolvedTitles).toEqual(["Missing"]);
+  });
+
+  test("same title with multiple hits expands all matching seeds", () => {
+    // Two distinct nodes share label "Dup"
+    const graph = buildGraph({ d1: "Dup", d2: "Dup", x: "X", y: "Y" }, [
+      directedEdge("e1", "d1", "x"),
+      directedEdge("e2", "d2", "y"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["Dup"], direction: "outgoing" }],
+      ops: [],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["d1", "d2", "x", "y"]);
+  });
+
+  test("empty seedTitles produces empty result without unresolved entries", () => {
+    const graph = buildGraph({ a: "A" }, []);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: [], direction: "outgoing" }],
+      ops: [],
+    });
+    expect([...result.nodeIds]).toEqual([]);
+    expect(result.unresolvedTitles).toEqual([]);
+  });
+
+  test("whitespace-only and blank-line titles are skipped silently", () => {
+    const graph = buildGraph({ a: "A" }, []);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["", "   ", "\t"], direction: "outgoing" }],
+      ops: [],
+    });
+    expect([...result.nodeIds]).toEqual([]);
+    expect(result.unresolvedTitles).toEqual([]);
+  });
+
+  test("titles are trimmed before lookup", () => {
+    const graph = buildGraph({ a: "Project" }, []);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["  Project  "], direction: "outgoing" }],
+      ops: [],
+    });
+    expect([...result.nodeIds]).toEqual(["a"]);
+  });
+});
+
+describe("evaluateSubgraph - edge induction", () => {
+  test("only includes edges with both endpoints in the result", () => {
+    // P -> A -> B; A -> X
+    const graph = buildGraph({ p: "P", a: "A", b: "B", x: "X" }, [
+      directedEdge("e1", "p", "a"),
+      directedEdge("e2", "a", "b"),
+      directedEdge("e3", "a", "x"),
+    ]);
+    const result = evaluateSubgraph(graph, {
+      sources: [{ seedTitles: ["P"], direction: "outgoing", maxHops: 1 }],
+      ops: [],
+    });
+    expect([...result.nodeIds].sort()).toEqual(["a", "p"]);
+    expect([...result.edgeIds]).toEqual(["e1"]);
+  });
+});
+
+describe("evaluateSubgraph - empty queries", () => {
+  test("zero sources returns empty result", () => {
+    const graph = buildGraph({ a: "A" }, []);
+    const result = evaluateSubgraph(graph, { sources: [], ops: [] });
+    expect([...result.nodeIds]).toEqual([]);
+    expect([...result.edgeIds]).toEqual([]);
+    expect(result.unresolvedTitles).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- グラフ全体だと見にくい時に、ユーザーが指定したパターンに合うサブグラフだけを抽出して見られるようにする
- 中心ユースケース: 「特定ノード（プロジェクト等）→ 葉ノード」で末端の事象を探す
- MVP から **複数シード + 集合演算 (∪/∩/\\)** を含む
- 結果は既存メイングラフ上で **ハイライト / 絞り込み** をトグル切替（別ビューにはしない）

## Design

- パターンモデル: 「シード + 方向付き辿り」（Cypher 的 DSL は採らない）
- 葉ノード = **有向リンクで out-degree 0**。無向リンクは葉判定に含めず、traversal では双方向で辿る
- `leavesOnly + maxHops` は積集合（maxHops 範囲内 ∩ グラフ全体での葉）
- シード指定はタイトル完全一致テキスト入力 + ノード右クリックから投入
- 対象は `apps/pages` のみ
- simulation のノード集合は変更せず、描画レイヤだけ切替（フィルタを切ったとき位置が壊れないように）

## Changes

- `packages/core/src/subgraph.ts` (新規): 純関数 \`evaluateSubgraph\`（BFS、visited で循環断ち、方向ごとの辿り、葉判定、集合演算の左畳み込み、エッジ誘導）
- `packages/core/tests/subgraph.test.ts` (新規): 23 ケース
- `packages/core/src/index.ts`: `evaluateSubgraph` と関連型を re-export
- `apps/pages/src/features/subgraph/use-subgraph-query.ts` (新規): state + 評価 hook
- `apps/pages/src/features/subgraph/subgraph-panel.tsx` (新規): パネル UI
- `apps/pages/src/features/graph/graph-view.tsx`: パネル開閉ボタン、右クリック「このノートをシードに」、描画切替（highlight: opacity 0.15 / filter: 早期 return）

## Base

PR #28 (\`feat/link-direction\`) 上に乗っかります。#28 のマージ後に base を main に切替予定。

## Test plan

- [x] \`vp run checkAll\` 緑（lint / fmt / type / test 全部）
- [x] \`packages/core\` の単体テスト 23 ケース pass（既存 20 + 新規 23 = 43）
- [x] ブラウザ手動確認
  - [x] 右クリックから「このノートをシードに」でパネルが開きシードに投入される
  - [x] ハイライトモードで非マッチが opacity 0.15
  - [x] 絞り込みモードで非マッチが描画から消える
- [ ] 階層構造（プロジェクト → タスク → サブタスク）で葉のみフィルタの動作確認
- [ ] 複数シード + intersect / difference の動作確認
- [ ] 未解決タイトル警告の表示確認