### PR TITLE
fix(adapter-idb): deleteNote で参照リンクを cascade 削除する

### DIFF
--- a/packages/adapter-idb/src/index.ts
+++ b/packages/adapter-idb/src/index.ts
@@ -74,9 +74,19 @@ export const createIdbAdapter = async (config?: IdbAdapterConfig): Promise<Stora
     },
 
     deleteNote: async (id) => {
-      const s = store("notes", "readwrite");
-      s.delete(id);
-      await tx(s.transaction);
+      // Cascade-delete links referencing this note in the same transaction,
+      // mirroring the SQLite adapter's FK ON DELETE CASCADE.
+      const t = db.transaction(["notes", "links"], "readwrite");
+      const links = t.objectStore("links");
+      const notes = t.objectStore("notes");
+
+      const bySource = await req(links.index("sourceId").getAllKeys(id));
+      for (const key of bySource) links.delete(key);
+      const byTarget = await req(links.index("targetId").getAllKeys(id));
+      for (const key of byTarget) links.delete(key);
+      notes.delete(id);
+
+      await tx(t);
     },
 
     getContent: async (id) => {

--- a/packages/adapter-idb/tests/index.test.ts
+++ b/packages/adapter-idb/tests/index.test.ts
@@ -70,6 +70,20 @@ describe("notes", () => {
     await adapter.deleteNote("1");
     expect(await adapter.getNoteById("1")).toBeUndefined();
   });
+
+  test("deleteNote cascades to links referencing the note", async () => {
+    await adapter.insertNote(note("1", "A"));
+    await adapter.insertNote(note("2", "B"));
+    await adapter.insertNote(note("3", "C"));
+    await adapter.insertLink({ id: "l1", sourceId: "1", targetId: "2", direction: "undirected" });
+    await adapter.insertLink({ id: "l2", sourceId: "3", targetId: "1", direction: "directed" });
+    await adapter.insertLink({ id: "l3", sourceId: "2", targetId: "3", direction: "directed" });
+
+    await adapter.deleteNote("1");
+
+    const remaining = await adapter.getAllLinks();
+    expect(remaining.map((l) => l.id)).toEqual(["l3"]);
+  });
 });
 
 describe("content", () => {


### PR DESCRIPTION
## Summary
- グラフビューでノードを削除した後にリロードすると `node not found` で落ちる不具合を修正
- 原因: IDB アダプタの `deleteNote` がノートだけ消してリンクを放置していたため、次回 `getGraph` 時に孤児リンクを含む graphData が返り d3-force の `forceLink` が解決できなくなっていた
- SQLite アダプタは FK `ON DELETE CASCADE` で安全だったため、アダプタ間で挙動が乖離していた状態。IDB 側でも `notes` と `links` を同一トランザクションでまとめて削除して挙動を揃える

## Test plan
- [x] `packages/adapter-idb` の単体テストに cascade 削除のケースを追加（source 側 / target 側 / 無関係リンクの 3 パターン）
- [x] `vp test` (adapter-idb): 19 passed
- [x] `vp check` (adapter-idb): lint / fmt クリーン
- [ ] pages を起動し、ノード右クリック → 削除 → リロードで落ちないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)